### PR TITLE
feat(standards): add Access Layer Design Standard v1.0 (Master v2.0)

### DIFF
--- a/design-standards/AI_Native_Data_Product_Master_Design.md
+++ b/design-standards/AI_Native_Data_Product_Master_Design.md
@@ -1,7 +1,7 @@
 # AI-Native Data Product - Master Design Standard
 
-**Version:** 1.9  
-**Date:** April 15, 2026  
+**Version:** 2.0  
+**Date:** May 2026  
 **Document Type:** Design Standard / Reusable Template  
 **Purpose:** Define the architectural blueprint and design standards for modular, AI-native data products optimized for agentic consumption
 
@@ -25,6 +25,7 @@ The architecture enables progressive enhancement - starting with traditional dat
 ```
 LAYER 1: DESIGN STANDARDS (This Document + Module Standards)
 ├── Master Design Standard ← You are here
+├── Access Layer Design Standard (roles, grants, deployment timing)
 └── Module Design Standards (6 documents - created separately)
     ├── Domain/Subject Data Design Standard
     ├── Search Module Design Standard
@@ -533,7 +534,7 @@ Tables within each database:
 
 **Benefits**:
 - ✅ Clear module boundaries
-- ✅ Independent access control per module (GRANT DATABASE)
+- ✅ Independent access control per module (GRANT DATABASE) — see Access Layer Design Standard
 - ✅ Modules can be deployed incrementally
 - ✅ Separate space management per module
 - ✅ Aligns with modular architecture concept
@@ -697,13 +698,19 @@ The following considerations apply regardless of platform:
 
 Both must exist before any other module deploys.
 
+**Phase 1.5: Access Layer — initial grant**
+3. Create the three product roles (`{ProductName}_ROLE_READ`, `{ProductName}_ROLE_AGENT`, `{ProductName}_ROLE_ADMIN`) and grant SELECT on the Semantic and Memory databases. This is the minimum grant required for agents and operational tools to discover and read the data product. See _Access Layer Design Standard_.
+
 **Phase 2: Foundation (Domain & Observability)**
-3. Domain — core business entities; documentation and Semantic registration written on deploy
-4. Observability — begins monitoring Domain immediately; coverage expands as later modules deploy
+4. Domain — core business entities; documentation and Semantic registration written on deploy
+5. Observability — begins monitoring Domain immediately; coverage expands as later modules deploy
+
+**Phase 2.5: Access Layer — extend grants**
+6. Extend role grants to Domain and Observability databases. Apply further grants as Search and Prediction are deployed in Phase 3.
 
 **Phase 3: Enhancement (Search & Prediction)**
-5. Search — requires Domain entities to embed
-6. Prediction — requires Domain entities to featurise
+7. Search — requires Domain entities to embed
+8. Prediction — requires Domain entities to featurise
 
 ### Module Dependencies
 ```
@@ -712,16 +719,54 @@ Semantic ───────────────→ (hosts discovery metad
     │
     Both must exist first
     │
+Access Layer (1.5) ─────→ ROLE_READ, ROLE_AGENT, ROLE_ADMIN created
+                          SELECT granted on Semantic + Memory
+    │
 Domain ────────┬────────→ Search
                ├────────→ Prediction
                └────────→ (entity foundation for all modules)
 
 Observability ──────────→ Memory (closed-loop learning feedback)
+
+Access Layer (2.5) ─────→ SELECT extended to Domain + Observability
+                          (and Search, Prediction as deployed)
 ```
 
 ---
 
+## Access Layer
+
+Every AI-Native Data Product must deploy an Access Layer alongside its module DDL. The Access Layer creates standard database roles and grants them SELECT access to each module's databases, making the data product discoverable and queryable by agents and consumers as each module is deployed.
+
+### Why it is mandatory
+
+Without an Access Layer, a correctly deployed data product is operationally invisible: every consumer — agents, dashboards, reporting tools, and analysts — will be denied access regardless of how completely the module databases have been deployed.
+
+### Three standard roles
+
+Three roles are created per product, named `{ProductName}_ROLE_{TIER}`:
+
+| Role | Consumers | Purpose |
+|------|-----------|---------|
+| `{ProductName}_ROLE_READ` | Analysts, BI tools, ad-hoc SQL users | SELECT on module databases |
+| `{ProductName}_ROLE_AGENT` | AI agents, MCP servers, automated tools | SELECT on module databases; kept separate to allow independent lifecycle management |
+| `{ProductName}_ROLE_ADMIN` | Data product owner, data steward | SELECT on all databases |
+
+The roles themselves are data product artefacts — created once and owned by the data product team. Assigning specific users or service accounts to those roles is an operational event, not a design standard concern.
+
+### Relationship to Physical Naming Approaches
+
+In the recommended Approach 1 (separate databases per module), each module database receives its own grant — for example: `GRANT SELECT ON {ProductName}_Semantic TO {ProductName}_ROLE_READ`. In Approach 2 (single database), a single grant covers all modules: `GRANT SELECT ON {ProductName} TO {ProductName}_ROLE_READ`.
+
+In deployments that separate base tables and views into distinct databases, consumers should be granted access to the view-layer database only — not the base table database.
+
+**Full specification**: see `Access_Layer_Design_Standard.md`.
+
+---
+
 ## Glossary
+
+**Access Layer**: The mandatory access control artefact of an AI-Native Data Product. Creates standard database roles (`ROLE_READ`, `ROLE_AGENT`, `ROLE_ADMIN`) and grants them SELECT access to module databases, making the data product discoverable and queryable by all consumers. Deployed in two phases interleaved with the module deployment sequence. See _Access Layer Design Standard_.
 
 **Agent**: An autonomous software entity that can perceive, reason, and act - consuming data products to achieve goals.
 
@@ -767,6 +812,7 @@ Observability ──────────→ Memory (closed-loop learning fee
 
 | Version | Date | Author | Changes |
 |---------|------|--------|---------|
+| 2.0 | 2026-05 | Paul Dancer, Worldwide Data Architecture Team, Teradata | Added mandatory Access Layer. New section defining three standard roles (ROLE_READ, ROLE_AGENT, ROLE_ADMIN), two-phase grant timing (Phase 1.5 after Memory+Semantic, Phase 2.5 after Domain+Observability), and guidance for both naming approaches. Updated Documentation Hierarchy tree, Recommended Implementation Order, Module Dependencies diagram, Approach 1 benefits, and Glossary. Full specification in Access_Layer_Design_Standard.md. |
 | 1.9 | 2026-04-15 | Nathan Green, Worldwide Data Architecture Team, Teradata | Established platform neutrality throughout. Updated Executive Summary and Zero Data Duplication principle to remove Teradata-specific language. Added Platform-Neutral Design as Guiding Principle 7. Added Platform Profiles section defining the concept, structure, and current implementations. Refactored Design Constraints section: removed Teradata-Specific Optimizations subsection, added Platform Implementation Notes framing directing implementors to Platform Profiles. Updated Performance Considerations to be platform-neutral. |
 | 1.8 | 2026-03-20 | Nathan Green, Worldwide Data Architecture Team, Teradata | Corrected module deployment order. Memory and Semantic are now Phase 1 (both must exist before any other module deploys — Memory hosts documentation tables, Semantic hosts discovery metadata). Domain and Observability are Phase 2. Search and Prediction are Phase 3. Updated Implementation Order section and Module Dependencies diagram. |
 | 1.7 | 2026-03-20 | Nathan Green, Worldwide Data Architecture Team, Teradata | Fixed = 'Y' filter values in agent discovery example queries to = 1 to align with platform boolean standard. |

--- a/design-standards/AI_Native_Data_Product_Master_Design.md
+++ b/design-standards/AI_Native_Data_Product_Master_Design.md
@@ -1,7 +1,7 @@
 # AI-Native Data Product - Master Design Standard
 
 **Version:** 2.0  
-**Date:** May 2026  
+**Date:** 2026-05-07  
 **Document Type:** Design Standard / Reusable Template  
 **Purpose:** Define the architectural blueprint and design standards for modular, AI-native data products optimized for agentic consumption
 
@@ -812,7 +812,7 @@ In deployments that separate base tables and views into distinct databases, cons
 
 | Version | Date | Author | Changes |
 |---------|------|--------|---------|
-| 2.0 | 2026-05 | Paul Dancer, Worldwide Data Architecture Team, Teradata | Added mandatory Access Layer. New section defining three standard roles (ROLE_READ, ROLE_AGENT, ROLE_ADMIN), two-phase grant timing (Phase 1.5 after Memory+Semantic, Phase 2.5 after Domain+Observability), and guidance for both naming approaches. Updated Documentation Hierarchy tree, Recommended Implementation Order, Module Dependencies diagram, Approach 1 benefits, and Glossary. Full specification in Access_Layer_Design_Standard.md. |
+| 2.0 | 2026-05-07 | Paul Dancer, Worldwide Data Architecture Team, Teradata | Added mandatory Access Layer. New section defining three standard roles (ROLE_READ, ROLE_AGENT, ROLE_ADMIN), two-phase grant timing (Phase 1.5 after Memory+Semantic, Phase 2.5 after Domain+Observability), and guidance for both naming approaches. Updated Documentation Hierarchy tree, Recommended Implementation Order, Module Dependencies diagram, Approach 1 benefits, and Glossary. Full specification in Access_Layer_Design_Standard.md. |
 | 1.9 | 2026-04-15 | Nathan Green, Worldwide Data Architecture Team, Teradata | Established platform neutrality throughout. Updated Executive Summary and Zero Data Duplication principle to remove Teradata-specific language. Added Platform-Neutral Design as Guiding Principle 7. Added Platform Profiles section defining the concept, structure, and current implementations. Refactored Design Constraints section: removed Teradata-Specific Optimizations subsection, added Platform Implementation Notes framing directing implementors to Platform Profiles. Updated Performance Considerations to be platform-neutral. |
 | 1.8 | 2026-03-20 | Nathan Green, Worldwide Data Architecture Team, Teradata | Corrected module deployment order. Memory and Semantic are now Phase 1 (both must exist before any other module deploys — Memory hosts documentation tables, Semantic hosts discovery metadata). Domain and Observability are Phase 2. Search and Prediction are Phase 3. Updated Implementation Order section and Module Dependencies diagram. |
 | 1.7 | 2026-03-20 | Nathan Green, Worldwide Data Architecture Team, Teradata | Fixed = 'Y' filter values in agent discovery example queries to = 1 to align with platform boolean standard. |

--- a/design-standards/Access_Layer_Design_Standard.md
+++ b/design-standards/Access_Layer_Design_Standard.md
@@ -3,7 +3,7 @@
 
 | **Version** | 1.0 |
 |-------------|-----|
-| **Date** | May 2026 |
+| **Date** | 2026-05-07 |
 | **Status** | Active |
 | **Related documents** | AI_Native_Data_Product_Master_Design |
 
@@ -271,4 +271,4 @@ The assignment of specific users or service accounts to those roles is an **oper
 
 | Version | Date | Author | Changes |
 |---------|------|--------|---------|
-| 1.0 | May 2026 | Paul Dancer, Worldwide Data Architecture Team, Teradata | Initial Access Layer Design Standard. Established three-tier role model (ROLE_READ, ROLE_AGENT, ROLE_ADMIN), two-phase deployment timing (1.5 and 2.5), grant matrix, DCL template, artefact location convention, and required documentation record. Motivated by D01_MP deployment finding where all module databases were correctly deployed but all consumers received access denied (Error 3523), rendering the product operationally invisible. |
+| 1.0 | 2026-05-07 | Paul Dancer, Worldwide Data Architecture Team, Teradata | Initial Access Layer Design Standard. Established three-tier role model (ROLE_READ, ROLE_AGENT, ROLE_ADMIN), two-phase deployment timing (1.5 and 2.5), grant matrix, DCL template, artefact location convention, and required documentation record. Motivated by D01_MP deployment finding where all module databases were correctly deployed but all consumers received access denied (Error 3523), rendering the product operationally invisible. |

--- a/design-standards/Access_Layer_Design_Standard.md
+++ b/design-standards/Access_Layer_Design_Standard.md
@@ -1,0 +1,274 @@
+# Access Layer Design Standard
+## AI-Native Data Product Framework
+
+| **Version** | 1.0 |
+|-------------|-----|
+| **Date** | May 2026 |
+| **Status** | Active |
+| **Related documents** | AI_Native_Data_Product_Master_Design |
+
+---
+
+## 1. Purpose
+
+The Access Layer is the mandatory access control artefact of an AI-Native Data Product. It creates standard database roles and grants them SELECT access to each module's databases, making the data product discoverable and queryable by agents and consumers as each module is deployed.
+
+Without an Access Layer, a correctly deployed data product is operationally invisible: every consumer — agents, dashboards, reporting tools, and analysts — will be denied access regardless of how completely the module databases are deployed.
+
+---
+
+## 2. Core Principle
+
+**Consumers access the module database(s) that expose the public interface for that module.** In the standard `{ProductName}_{ModuleName}` deployment pattern, this is the module database itself (which contains both base tables and views). In deployments that separate base tables and views into distinct databases (e.g., `{ProductName}_{Module}_T` for tables and `{ProductName}_{Module}_V` for views), consumers should be granted access to the view-layer database only — not the base table database.
+
+This standard uses the term **module access database** to refer to whichever database(s) consumers should be granted access to for a given module, acknowledging that this varies by deployment approach.
+
+---
+
+## 3. Standard Roles
+
+Three roles are created per data product. Naming convention: `{ProductName}_ROLE_{TIER}`.
+
+| Role | Intended consumers | Scope |
+|------|--------------------|-------|
+| `{ProductName}_ROLE_READ` | Analysts, BI tools, ad-hoc SQL users | SELECT on module access databases |
+| `{ProductName}_ROLE_AGENT` | AI agents, MCP servers, automated tools | SELECT on module access databases |
+| `{ProductName}_ROLE_ADMIN` | Data product owner, data steward | SELECT on all databases including any separate base table databases |
+
+### 3.1 Why ROLE_AGENT is separate from ROLE_READ
+
+`ROLE_AGENT` and `ROLE_READ` grant the same SELECT scope by default but are kept as distinct roles for three reasons:
+
+1. **Independent lifecycle** — agent access can be suspended, extended, or revoked without affecting human analyst access.
+2. **Selective extension** — some products may grant agents write-back capability (for example, INSERT to Memory module tables to record agent interactions). This extension can be applied to `ROLE_AGENT` without broadening `ROLE_READ`.
+3. **Audit clarity** — agent-originated queries are separately auditable when the connecting user holds a distinct role.
+
+---
+
+## 4. Deployment Timing
+
+The Access Layer deploys in two phases, interleaved with the module deployment sequence:
+
+| Phase | Timing | Action |
+|-------|--------|--------|
+| **Phase 1.5** | Immediately after Phase 1 (Memory + Semantic) | Create roles; grant on Semantic and Memory module access databases |
+| **Phase 2.5** | Immediately after Phase 2 (Domain + Observability) and as further modules deploy | Extend grants to Domain, Observability, and any subsequent module databases |
+
+**Phase 1.5 is the minimum viable access grant.** Once Semantic and Memory are readable, agents can discover the data product's structure, read the business glossary, and use the query cookbook. Operational tools such as data product dashboards can begin populating.
+
+Delaying all grants until every module is fully deployed is an anti-pattern: consumers cannot validate the product during incremental deployment, and access problems are discovered later than necessary.
+
+---
+
+## 5. Grant Matrix
+
+| Module | ROLE_READ | ROLE_AGENT | ROLE_ADMIN |
+|--------|-----------|------------|------------|
+| Semantic | ✅ Phase 1.5 | ✅ Phase 1.5 | ✅ Phase 1.5 |
+| Memory | ✅ Phase 1.5 | ✅ Phase 1.5 | ✅ Phase 1.5 |
+| Domain | ✅ Phase 2.5 | ✅ Phase 2.5 | ✅ Phase 2.5 |
+| Observability | ✅ Phase 2.5 | ✅ Phase 2.5 | ✅ Phase 2.5 |
+| Search | ✅ when deployed | ✅ when deployed | ✅ when deployed |
+| Prediction | ✅ when deployed | ✅ when deployed | ✅ when deployed |
+| Base table databases (if separate) | ❌ | ❌ | ✅ |
+
+Grants to Search and Prediction are applied as those modules are deployed, following the same Phase 2.5 pattern.
+
+---
+
+## 6. DCL Template (Teradata)
+
+The following template targets the standard `{ProductName}_{ModuleName}` deployment pattern. Teams using a separate view-layer database (e.g., `{ProductName}_{Module}_V`) should substitute the appropriate database names. See the Teradata Platform Profile (`Advocated_Data_Management_Standards.md`) for platform-specific syntax notes.
+
+```sql
+-- =============================================================================
+-- ACCESS LAYER — {ProductName} Data Product
+-- File: 00-access/{ProductName}_access_layer.dcl
+--
+-- Phase 1.5: Apply after Memory + Semantic are deployed.
+-- Phase 2.5: Apply after Domain + Observability are deployed.
+--            Add further GRANT blocks as additional modules are deployed.
+-- =============================================================================
+
+-- ── Create roles ──────────────────────────────────────────────────────────────
+
+CREATE ROLE {ProductName}_ROLE_READ;
+COMMENT ON ROLE {ProductName}_ROLE_READ IS
+    '{ProductName} data product — read-only access for analysts and BI tools.
+     Grants SELECT on all module access databases.';
+
+CREATE ROLE {ProductName}_ROLE_AGENT;
+COMMENT ON ROLE {ProductName}_ROLE_AGENT IS
+    '{ProductName} data product — AI agent and automated tool access.
+     Grants SELECT on all module access databases. Kept separate from
+     ROLE_READ to allow independent lifecycle management and selective
+     extension (e.g., agent write-back to Memory).';
+
+CREATE ROLE {ProductName}_ROLE_ADMIN;
+COMMENT ON ROLE {ProductName}_ROLE_ADMIN IS
+    '{ProductName} data product — data product owner and data steward access.
+     Grants SELECT on all databases.';
+
+-- ── Phase 1.5 — apply after Memory + Semantic are deployed ───────────────────
+
+GRANT SELECT ON {ProductName}_Semantic TO {ProductName}_ROLE_READ;
+GRANT SELECT ON {ProductName}_Semantic TO {ProductName}_ROLE_AGENT;
+GRANT SELECT ON {ProductName}_Semantic TO {ProductName}_ROLE_ADMIN;
+
+GRANT SELECT ON {ProductName}_Memory   TO {ProductName}_ROLE_READ;
+GRANT SELECT ON {ProductName}_Memory   TO {ProductName}_ROLE_AGENT;
+GRANT SELECT ON {ProductName}_Memory   TO {ProductName}_ROLE_ADMIN;
+
+-- ── Phase 2.5 — apply after Domain + Observability are deployed ───────────────
+
+GRANT SELECT ON {ProductName}_Domain        TO {ProductName}_ROLE_READ;
+GRANT SELECT ON {ProductName}_Domain        TO {ProductName}_ROLE_AGENT;
+GRANT SELECT ON {ProductName}_Domain        TO {ProductName}_ROLE_ADMIN;
+
+GRANT SELECT ON {ProductName}_Observability TO {ProductName}_ROLE_READ;
+GRANT SELECT ON {ProductName}_Observability TO {ProductName}_ROLE_AGENT;
+GRANT SELECT ON {ProductName}_Observability TO {ProductName}_ROLE_ADMIN;
+
+-- ── When Search is deployed ───────────────────────────────────────────────────
+
+-- GRANT SELECT ON {ProductName}_Search      TO {ProductName}_ROLE_READ;
+-- GRANT SELECT ON {ProductName}_Search      TO {ProductName}_ROLE_AGENT;
+-- GRANT SELECT ON {ProductName}_Search      TO {ProductName}_ROLE_ADMIN;
+
+-- ── When Prediction is deployed ───────────────────────────────────────────────
+
+-- GRANT SELECT ON {ProductName}_Prediction  TO {ProductName}_ROLE_READ;
+-- GRANT SELECT ON {ProductName}_Prediction  TO {ProductName}_ROLE_AGENT;
+-- GRANT SELECT ON {ProductName}_Prediction  TO {ProductName}_ROLE_ADMIN;
+
+-- ── Assign roles to users and service accounts ────────────────────────────────
+-- Roles are product artefacts — created once, owned by the data product team.
+-- User-to-role assignments are operational events.
+-- Replace placeholders with the actual usernames for this environment.
+
+-- AI agent / MCP server service account:
+-- GRANT {ProductName}_ROLE_AGENT TO {agent_service_account};
+
+-- Analyst or BI tool user (or grant to an existing organisational group role):
+-- GRANT {ProductName}_ROLE_READ TO {analyst_user_or_group_role};
+
+-- Data product owner / data steward:
+-- GRANT {ProductName}_ROLE_ADMIN TO {product_owner_user};
+```
+
+---
+
+## 7. Artefact Location
+
+The DCL file lives in a `00-access/` directory at the root of the data product's artefact tree. The `00-` prefix marks it as a pre-requisite that must be visible alongside the module directories:
+
+```
+{ProductName}/
+├── 00-access/
+│   └── {ProductName}_access_layer.dcl
+├── 01-memory/
+├── 02-semantic/
+├── 03-domain/
+├── 04-observability/
+├── 05-search/           (if implemented)
+└── 06-prediction/       (if implemented)
+```
+
+The two-phase structure is documented in the file's comments. How the two phases are executed — whether as a single pass, two separate executions, or any other delivery mechanism — is left to the team deploying the product.
+
+---
+
+## 8. Required Documentation Record
+
+Deployment of the Access Layer must produce a `Design_Decision` record in `{ProductName}_Memory.Design_Decision`. This is mandatory under the Documentation Capture Protocol in the Master Design Standard.
+
+```sql
+INSERT INTO {ProductName}_Memory.Design_Decision
+(
+    decision_id,
+    decision_version,
+    decision_title,
+    decision_description,
+    context,
+    alternatives_considered,
+    rationale,
+    decision_status,
+    decision_category,
+    source_module,
+    module_version,
+    decided_date,
+    valid_from,
+    valid_to,
+    is_current
+)
+VALUES
+(
+    'DD-ACCESS-001',
+    1,
+    'Three-tier role model for data product access control',
+
+    'Three database roles are created per product:
+     {ProductName}_ROLE_READ for analysts and BI tools,
+     {ProductName}_ROLE_AGENT for AI agents and automated tools,
+     {ProductName}_ROLE_ADMIN for the product owner and data steward.
+     All consumer roles receive SELECT on the module access databases.
+     ROLE_ADMIN additionally receives access to any separate base table
+     databases.',
+
+    'Consumers — agents, dashboards, and tools — require SELECT on the
+     Semantic and Memory databases at minimum to discover and operate the
+     data product. Without this, the product is physically deployed but
+     operationally invisible to all consumers.',
+
+    'Option 1 (chosen): Three distinct roles with separate READ and AGENT tiers.
+     Option 2: Single consumer role — rejected because READ and AGENT access
+     cannot then be independently managed or extended.
+     Option 3: Direct per-user grants — rejected because this does not scale
+     and prevents role-based revocation.',
+
+    'Keeping ROLE_AGENT separate from ROLE_READ enables independent lifecycle
+     management of AI tooling access and permits selective extension
+     (e.g., agent write-back to Memory) without broadening analyst access.',
+
+    'ACCEPTED',
+    'SECURITY',
+    'ACCESS',
+    '1.0',
+    CURRENT_DATE,
+    CURRENT_DATE,
+    DATE '9999-12-31',
+    1
+);
+```
+
+---
+
+## 9. Relationship to Module Design Standards
+
+Each module design standard defines **what** that module contains and **what** it registers in Semantic and Memory on deployment. The Access Layer defines **who** can read each module after deployment.
+
+The roles themselves (`{ProductName}_ROLE_READ`, `_ROLE_AGENT`, `_ROLE_ADMIN`) are **data product artefacts** — created once when the product is first deployed and owned by the data product team.
+
+The assignment of specific users or service accounts to those roles is an **operational event** — outside the scope of these design standards and managed through whatever access request and approval process the data product team operates.
+
+---
+
+## 10. Checklist
+
+- [ ] `{ProductName}_ROLE_READ` created with COMMENT
+- [ ] `{ProductName}_ROLE_AGENT` created with COMMENT
+- [ ] `{ProductName}_ROLE_ADMIN` created with COMMENT
+- [ ] Phase 1.5 grants applied (Semantic, Memory) immediately after Phase 1 deployed
+- [ ] Phase 2.5 grants applied (Domain, Observability) immediately after Phase 2 deployed
+- [ ] Search and Prediction grants applied as each is deployed
+- [ ] Service accounts and users assigned to appropriate roles for this environment
+- [ ] `DD-ACCESS-001` Design_Decision record inserted into `{ProductName}_Memory`
+- [ ] DCL file committed as `00-access/{ProductName}_access_layer.dcl`
+
+---
+
+## Document Control
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0 | May 2026 | Paul Dancer, Worldwide Data Architecture Team, Teradata | Initial Access Layer Design Standard. Established three-tier role model (ROLE_READ, ROLE_AGENT, ROLE_ADMIN), two-phase deployment timing (1.5 and 2.5), grant matrix, DCL template, artefact location convention, and required documentation record. Motivated by D01_MP deployment finding where all module databases were correctly deployed but all consumers received access denied (Error 3523), rendering the product operationally invisible. |


### PR DESCRIPTION
Add mandatory access control artefact specification to the AI-Native Data Product framework.

New file:
- design-standards/Access_Layer_Design_Standard.md

  Defines three standard Teradata roles per product (ROLE_READ, ROLE_AGENT, ROLE_ADMIN), a two-phase grant timing model (Phase 1.5 after Memory+Semantic, Phase 2.5 after Domain+Observability), grant matrix, DCL template, artefact layout convention (00-access/), and required Design_Decision documentation record.

Modified:
- design-standards/AI_Native_Data_Product_Master_Design.md (v1.9 → v2.0)

  - Documentation hierarchy tree: listed Access_Layer_Design_Standard
  - Recommended Implementation Order: inserted Phase 1.5 and 2.5; renumbered subsequent steps
  - Module Dependencies diagram: added Access Layer at both timing points
  - Physical Naming Approach 1 benefits: expanded GRANT DATABASE note
  - New section "Access Layer": summary of roles, mandatory rationale, and guidance for both naming convention approaches
  - Glossary: added Access Layer entry
  - Document Control: v2.0 entry

Motivation: Mortgage Platform demo deployment showed that all six module databases can be correctly deployed while every consumer receives access denied (Teradata Error 3523), rendering the product operationally invisible to agents, dashboards, and analysts alike. The Access Layer closes that gap as a mandatory deployment artefact.

No module design standards were modified.
Note: regenerate the unified Claude skill using Skill_Conversion_Prompt.md after merging.