### PR TITLE
docs(advocated): add Section 6 (Access Layer), defer placement to OPS

### DIFF
--- a/design-standards/Advocated_Data_Management_Standards.md
+++ b/design-standards/Advocated_Data_Management_Standards.md
@@ -1,4 +1,5 @@
 # Advocated Data Management Standards
+
 ## AI-Native Data Product Architecture - Teradata Recommendations
 
 ---
@@ -6,10 +7,10 @@
 ## Document Control
 
 | Attribute | Value |
-|-----------|-------|
-| **Version** | 1.5 |
+| --- | --- |
+| **Version** | 1.6 |
 | **Status** | GUIDANCE |
-| **Last Updated** | 2026-04-10 |
+| **Last Updated** | 2026-05-08 |
 | **Owner** | Data Architecture |
 | **Scope** | Cross-Module Data Management Guidance |
 | **Type** | Recommended Practices |
@@ -23,11 +24,13 @@
 3. [Column Optimization Strategy](#3-column-optimization-strategy)
 4. [Surrogate Key Strategy](#4-surrogate-key-strategy)
 5. [Soft Delete Pattern](#5-soft-delete-pattern)
-6. [Observability Offload Pattern](#6-observability-offload-pattern)
-7. [Timezone Handling](#7-timezone-handling)
-8. [Data Quality Management](#8-data-quality-management)
-9. [Audit Trail Strategy](#9-audit-trail-strategy)
-10. [Implementation Decision Trees](#10-implementation-decision-trees)
+6. [Access Layer](#6-access-layer)
+7. [Observability Offload Pattern](#7-observability-offload-pattern)
+8. [Timezone Handling](#8-timezone-handling)
+9. [Data Quality Management](#9-data-quality-management)
+10. [Audit Trail Strategy](#10-audit-trail-strategy)
+11. [Platform Implementation Guidance: Teradata](#11-platform-implementation-guidance-teradata)
+12. [Implementation Decision Trees](#12-implementation-decision-trees)
 
 ---
 
@@ -42,22 +45,24 @@ This document provides **Teradata's recommended practices** for data management 
 ### 1.2 How to Use This Guidance
 
 | Your Situation | How to Apply |
-|----------------|--------------|
+| --- | --- |
 | **Starting fresh** | Adopt these practices as defaults |
 | **Existing patterns** | Evaluate selective adoption |
 | **Specific constraints** | Adapt patterns to your context |
 | **Different philosophy** | Document your alternative approach |
 
+
 ### 1.3 Advocacy vs Mandate
 
 | This Document ADVOCATES | Design Standard MANDATES |
-|------------------------|--------------------------|
+| --- | --- |
 | Bi-temporal tracking | Module structure |
 | Surrogate keys | Naming conventions |
 | Soft deletes | Cross-module integration patterns |
 | Observability offload | Agent discoverability |
 | TIMESTAMP WITH TIME ZONE | View standards |
 | Column optimization | - |
+
 
 **Remember**: You can build AI-Native data products using different temporal patterns, different key strategies, or different column approaches—as long as you follow the structural patterns in the Design Standard.
 
@@ -67,13 +72,12 @@ This document provides **Teradata's recommended practices** for data management 
 
 ### 2.1 Why We Advocate Bi-Temporal
 
-**Traditional Approach**: Type 2 SCD (single time dimension)
-**Advocated Approach**: Bi-temporal (two independent time dimensions)
+**Traditional Approach**: Type 2 SCD (single time dimension) **Advocated Approach**: Bi-temporal (two independent time dimensions)
 
 #### Key Benefits for AI-Native Data Products
 
 | Requirement | Type 2 SCD | Bi-Temporal |
-|-------------|-----------|-------------|
+| --- | --- | --- |
 | **Point-in-time correctness** | ⚠️ Approximate | ✅ Exact |
 | **Late-arriving facts** | ❌ Corrupts history | ✅ Preserves history |
 | **Corrections tracking** | ❌ Lost | ✅ Traceable |
@@ -81,217 +85,203 @@ This document provides **Teradata's recommended practices** for data management 
 | **Audit trail** | ⚠️ Partial | ✅ Complete |
 | **Explainability** | ⚠️ Limited | ✅ Full reconstruction |
 
+
 ### 2.2 The Two Time Dimensions
 
-```
-Example: Customer changes name from "Jane Doe" to "Jane Smith"
+    Example: Customer changes name from "Jane Doe" to "Jane Smith"
 
-Real World Event:
-- Marriage happens on 2024-06-15 (Valid Time)
+    Real World Event:
+    - Marriage happens on 2024-06-15 (Valid Time)
 
-Database Recording:
-- We learn about it on 2024-07-01 (Transaction Time)
+    Database Recording:
+    - We learn about it on 2024-07-01 (Transaction Time)
 
-Bi-Temporal Record:
-- valid_from_dts = 2024-06-15 (when it became true in reality)
-- transaction_from_dts = 2024-07-01 (when we recorded it)
-```
+    Bi-Temporal Record:
+    - valid_from_dts = 2024-06-15 (when it became true in reality)
+    - transaction_from_dts = 2024-07-01 (when we recorded it)
 
-**Valid Time**: When the fact was TRUE in the real world
-**Transaction Time**: When the fact was RECORDED in the database
+**Valid Time**: When the fact was TRUE in the real world **Transaction Time**: When the fact was RECORDED in the database
 
 ### 2.3 Advocated Bi-Temporal Column Set
 
-```sql
--- ADVOCATED: Bi-temporal columns
-valid_from_dts      TIMESTAMP(6) WITH TIME ZONE NOT NULL
-    COMMENT 'When this version became true in real world',
+    -- ADVOCATED: Bi-temporal columns
+    valid_from_dts      TIMESTAMP(6) WITH TIME ZONE NOT NULL
+        COMMENT 'When this version became true in real world',
 
-valid_to_dts        TIMESTAMP(6) WITH TIME ZONE NOT NULL 
-    DEFAULT TIMESTAMP '9999-12-31 23:59:59.999999+00:00'
-    COMMENT 'When this version stopped being true in real world',
+    valid_to_dts        TIMESTAMP(6) WITH TIME ZONE NOT NULL
+        DEFAULT TIMESTAMP '9999-12-31 23:59:59.999999+00:00'
+        COMMENT 'When this version stopped being true in real world',
 
-transaction_from_dts TIMESTAMP(6) WITH TIME ZONE NOT NULL 
-    DEFAULT CURRENT_TIMESTAMP(6)
-    COMMENT 'When this version was inserted into database',
+    transaction_from_dts TIMESTAMP(6) WITH TIME ZONE NOT NULL
+        DEFAULT CURRENT_TIMESTAMP(6)
+        COMMENT 'When this version was inserted into database',
 
-transaction_to_dts   TIMESTAMP(6) WITH TIME ZONE NOT NULL 
-    DEFAULT TIMESTAMP '9999-12-31 23:59:59.999999+00:00'
-    COMMENT 'When this version was superseded in database',
+    transaction_to_dts   TIMESTAMP(6) WITH TIME ZONE NOT NULL
+        DEFAULT TIMESTAMP '9999-12-31 23:59:59.999999+00:00'
+        COMMENT 'When this version was superseded in database',
 
-is_current  BYTEINT NOT NULL DEFAULT 1
-    COMMENT '1 = Current version, 0 = Historical version',
-```
+    is_current  BYTEINT NOT NULL DEFAULT 1
+        COMMENT '1 = Current version, 0 = Historical version',
 
 **IMPORTANT: PRIMARY INDEX for Temporal Tables**
 
 Temporal tables (bi-temporal, Type 2 SCD, versioned) should use **PRIMARY INDEX** (NUPI), not UNIQUE PRIMARY INDEX, because:
+
 - Multiple versions exist for the same entity_id
 - Historical records create natural duplicates
 - UNIQUE PRIMARY INDEX would prevent version updates
 
-```sql
--- CORRECT for temporal tables
-CREATE TABLE Party_H (
-    party_id BIGINT NOT NULL,
-    -- ... bi-temporal columns ...
-)
-PRIMARY INDEX (party_id);  -- NUPI allows multiple versions
 
--- INCORRECT for temporal tables
-CREATE TABLE Party_H (
-    party_id BIGINT NOT NULL,
-    -- ... bi-temporal columns ...
-)
-UNIQUE PRIMARY INDEX (party_id);  -- Would fail on version 2
-```
+    -- CORRECT for temporal tables
+    CREATE TABLE Party_H (
+        party_id BIGINT NOT NULL,
+        -- ... bi-temporal columns ...
+    )
+    PRIMARY INDEX (party_id);  -- NUPI allows multiple versions
+
+    -- INCORRECT for temporal tables
+    CREATE TABLE Party_H (
+        party_id BIGINT NOT NULL,
+        -- ... bi-temporal columns ...
+    )
+    UNIQUE PRIMARY INDEX (party_id);  -- Would fail on version 2
 
 **Use UNIQUE PRIMARY INDEX only for:**
+
 - Non-temporal tables (no versioning)
 - Reference data with unique codes
 - Tables where each key appears exactly once
+
 
 ### 2.4 Bi-Temporal Operations
 
 #### Insert New Entity (Version 1)
 
-```sql
-INSERT INTO Party_H (
-    party_id, party_key, legal_name,
-    valid_from_dts, valid_to_dts,
-    transaction_from_dts, transaction_to_dts,
-    is_current, is_deleted
-) VALUES (
-    1001, 'CUST-12345', 'Jane Doe',
-    TIMESTAMP '2024-01-01 00:00:00+00:00',
-    TIMESTAMP '9999-12-31 23:59:59.999999+00:00',
-    CURRENT_TIMESTAMP(6),
-    TIMESTAMP '9999-12-31 23:59:59.999999+00:00',
-    1, 0
-);
-```
+    INSERT INTO Party_H (
+        party_id, party_key, legal_name,
+        valid_from_dts, valid_to_dts,
+        transaction_from_dts, transaction_to_dts,
+        is_current, is_deleted
+    ) VALUES (
+        1001, 'CUST-12345', 'Jane Doe',
+        TIMESTAMP '2024-01-01 00:00:00+00:00',
+        TIMESTAMP '9999-12-31 23:59:59.999999+00:00',
+        CURRENT_TIMESTAMP(6),
+        TIMESTAMP '9999-12-31 23:59:59.999999+00:00',
+        1, 0
+    );
 
 #### Update Entity (Create Version 2)
 
-```sql
--- Step 1: Close out current version
-UPDATE Party_H
-SET valid_to_dts = TIMESTAMP '2024-06-15 00:00:00+00:00',
-    transaction_to_dts = CURRENT_TIMESTAMP(6),
-    is_current = 0
-WHERE party_id = 1001 AND is_current = 1;
+    -- Step 1: Close out current version
+    UPDATE Party_H
+    SET valid_to_dts = TIMESTAMP '2024-06-15 00:00:00+00:00',
+        transaction_to_dts = CURRENT_TIMESTAMP(6),
+        is_current = 0
+    WHERE party_id = 1001 AND is_current = 1;
 
--- Step 2: Insert new version
-INSERT INTO Party_H (
-    party_id, party_key, legal_name,
-    valid_from_dts, valid_to_dts,
-    transaction_from_dts, transaction_to_dts,
-    is_current, is_deleted
-) VALUES (
-    1001, 'CUST-12345', 'Jane Smith',  -- NAME CHANGED
-    TIMESTAMP '2024-06-15 00:00:00+00:00',  -- When change occurred
-    TIMESTAMP '9999-12-31 23:59:59.999999+00:00',
-    CURRENT_TIMESTAMP(6),  -- When we recorded it
-    TIMESTAMP '9999-12-31 23:59:59.999999+00:00',
-    1, 0
-);
-```
+    -- Step 2: Insert new version
+    INSERT INTO Party_H (
+        party_id, party_key, legal_name,
+        valid_from_dts, valid_to_dts,
+        transaction_from_dts, transaction_to_dts,
+        is_current, is_deleted
+    ) VALUES (
+        1001, 'CUST-12345', 'Jane Smith',  -- NAME CHANGED
+        TIMESTAMP '2024-06-15 00:00:00+00:00',  -- When change occurred
+        TIMESTAMP '9999-12-31 23:59:59.999999+00:00',
+        CURRENT_TIMESTAMP(6),  -- When we recorded it
+        TIMESTAMP '9999-12-31 23:59:59.999999+00:00',
+        1, 0
+    );
 
 #### Correct Historical Data (Late-Arriving Fact)
 
-```sql
--- Scenario: Discovered marriage actually happened on 2024-06-10, not 2024-06-15
--- We need to correct valid_from_dts but preserve transaction history
+    -- Scenario: Discovered marriage actually happened on 2024-06-10, not 2024-06-15
+    -- We need to correct valid_from_dts but preserve transaction history
 
--- Step 1: Close incorrect version in transaction time
-UPDATE Party_H
-SET transaction_to_dts = CURRENT_TIMESTAMP(6),
-    is_current = 0
-WHERE party_id = 1001
-  AND valid_from_dts = TIMESTAMP '2024-06-15 00:00:00+00:00'
-  AND is_current = 1;
+    -- Step 1: Close incorrect version in transaction time
+    UPDATE Party_H
+    SET transaction_to_dts = CURRENT_TIMESTAMP(6),
+        is_current = 0
+    WHERE party_id = 1001
+      AND valid_from_dts = TIMESTAMP '2024-06-15 00:00:00+00:00'
+      AND is_current = 1;
 
--- Step 2: Insert corrected version with new transaction time
-INSERT INTO Party_H (
-    party_id, party_key, legal_name,
-    valid_from_dts, valid_to_dts,
-    transaction_from_dts, transaction_to_dts,
-    is_current, is_deleted
-) VALUES (
-    1001, 'CUST-12345', 'Jane Smith',
-    TIMESTAMP '2024-06-10 00:00:00+00:00',  -- CORRECTED valid time
-    TIMESTAMP '9999-12-31 23:59:59.999999+00:00',
-    CURRENT_TIMESTAMP(6),  -- NEW transaction time
-    TIMESTAMP '9999-12-31 23:59:59.999999+00:00',
-    1, 0
-);
+    -- Step 2: Insert corrected version with new transaction time
+    INSERT INTO Party_H (
+        party_id, party_key, legal_name,
+        valid_from_dts, valid_to_dts,
+        transaction_from_dts, transaction_to_dts,
+        is_current, is_deleted
+    ) VALUES (
+        1001, 'CUST-12345', 'Jane Smith',
+        TIMESTAMP '2024-06-10 00:00:00+00:00',  -- CORRECTED valid time
+        TIMESTAMP '9999-12-31 23:59:59.999999+00:00',
+        CURRENT_TIMESTAMP(6),  -- NEW transaction time
+        TIMESTAMP '9999-12-31 23:59:59.999999+00:00',
+        1, 0
+    );
 
--- Result: Complete history preserved
--- - What we thought (2024-06-15) - closed in transaction time
--- - What actually happened (2024-06-10) - current
-```
+    -- Result: Complete history preserved
+    -- - What we thought (2024-06-15) - closed in transaction time
+    -- - What actually happened (2024-06-10) - current
 
 ### 2.5 Advocated Query Patterns
 
 #### Get Current State
 
-```sql
-SELECT party_id, party_key, legal_name
-FROM Party_H
-WHERE party_key = 'CUST-12345'
-  AND is_current = 1
-  AND is_deleted = 0;
-```
+    SELECT party_id, party_key, legal_name
+    FROM Party_H
+    WHERE party_key = 'CUST-12345'
+      AND is_current = 1
+      AND is_deleted = 0;
 
 #### Point-in-Time Query (for ML Features)
 
-```sql
--- "What was the customer's name on 2024-05-01?"
--- Critical for computing features with temporal correctness
-SELECT party_id, party_key, legal_name
-FROM Party_H
-WHERE party_key = 'CUST-12345'
-  AND TIMESTAMP '2024-05-01 00:00:00+00:00' >= valid_from_dts
-  AND TIMESTAMP '2024-05-01 00:00:00+00:00' < valid_to_dts
-  AND is_deleted = 0
-  AND transaction_from_dts = (
-      SELECT MAX(transaction_from_dts)
-      FROM Party_H p2
-      WHERE p2.party_id = Party_H.party_id
-        AND p2.transaction_from_dts <= TIMESTAMP '2024-05-01 23:59:59.999999+00:00'
-  );
-```
+    -- "What was the customer's name on 2024-05-01?"
+    -- Critical for computing features with temporal correctness
+    SELECT party_id, party_key, legal_name
+    FROM Party_H
+    WHERE party_key = 'CUST-12345'
+      AND TIMESTAMP '2024-05-01 00:00:00+00:00' >= valid_from_dts
+      AND TIMESTAMP '2024-05-01 00:00:00+00:00' < valid_to_dts
+      AND is_deleted = 0
+      AND transaction_from_dts = (
+          SELECT MAX(transaction_from_dts)
+          FROM Party_H p2
+          WHERE p2.party_id = Party_H.party_id
+            AND p2.transaction_from_dts <= TIMESTAMP '2024-05-01 23:59:59.999999+00:00'
+      );
 
 #### As-Of Query (Transaction Time)
 
-```sql
--- "What did our database show on 2024-07-15 (before correction)?"
-SELECT party_id, party_key, legal_name
-FROM Party_H
-WHERE party_key = 'CUST-12345'
-  AND transaction_from_dts <= TIMESTAMP '2024-07-15 23:59:59.999999+00:00'
-  AND transaction_to_dts > TIMESTAMP '2024-07-15 23:59:59.999999+00:00';
-```
+    -- "What did our database show on 2024-07-15 (before correction)?"
+    SELECT party_id, party_key, legal_name
+    FROM Party_H
+    WHERE party_key = 'CUST-12345'
+      AND transaction_from_dts <= TIMESTAMP '2024-07-15 23:59:59.999999+00:00'
+      AND transaction_to_dts > TIMESTAMP '2024-07-15 23:59:59.999999+00:00';
 
 ### 2.6 Alternative: Type 2 SCD (When Acceptable)
 
 **Use Type 2 SCD instead of bi-temporal when:**
+
 - Late-arriving facts are extremely rare
 - Corrections are not needed
 - ML features don't require point-in-time correctness
 - Simpler is better for your use case
 
-```sql
--- Type 2 SCD (simpler temporal)
-CREATE TABLE Party_H (
-    party_id BIGINT NOT NULL,
-    party_key VARCHAR(50) NOT NULL,
-    effective_date DATE NOT NULL,
-    expiration_date DATE NOT NULL DEFAULT DATE '9999-12-31',
-    is_current BYTEINT NOT NULL DEFAULT 1,
-    -- ... other columns ...
-);
-```
+
+    -- Type 2 SCD (simpler temporal)
+    CREATE TABLE Party_H (
+        party_id BIGINT NOT NULL,
+        party_key VARCHAR(50) NOT NULL,
+        effective_date DATE NOT NULL,
+        expiration_date DATE NOT NULL DEFAULT DATE '9999-12-31',
+        is_current BYTEINT NOT NULL DEFAULT 1,
+        -- ... other columns ...
+    );
 
 **Trade-off**: Simpler implementation, but loses ability to handle corrections and lacks transaction-time dimension.
 
@@ -301,9 +291,7 @@ CREATE TABLE Party_H (
 
 ### 3.1 The Column Overhead Challenge
 
-**Traditional Standards**: 20+ standard columns per table
-**Problem**: Significant overhead on high-volume tables
-**Advocated Solution**: Three-tier approach
+**Traditional Standards**: 20+ standard columns per table **Problem**: Significant overhead on high-volume tables **Advocated Solution**: Three-tier approach
 
 ### 3.2 Three-Tier Column Strategy
 
@@ -311,66 +299,61 @@ CREATE TABLE Party_H (
 
 **Minimum viable set for AI-Native domain tables:**
 
-```sql
-{entity}_id        BIGINT NOT NULL             -- Surrogate key
-{entity}_key       VARCHAR(50) NOT NULL        -- Natural key
-valid_from_dts      TIMESTAMP(6) WITH TIME ZONE NOT NULL
-valid_to_dts        TIMESTAMP(6) WITH TIME ZONE NOT NULL
-transaction_from_dts TIMESTAMP(6) WITH TIME ZONE NOT NULL
-transaction_to_dts   TIMESTAMP(6) WITH TIME ZONE NOT NULL
-is_current  BYTEINT NOT NULL DEFAULT 1
-is_deleted          BYTEINT NOT NULL DEFAULT 0
-```
+    {entity}_id        BIGINT NOT NULL             -- Surrogate key
+    {entity}_key       VARCHAR(50) NOT NULL        -- Natural key
+    valid_from_dts      TIMESTAMP(6) WITH TIME ZONE NOT NULL
+    valid_to_dts        TIMESTAMP(6) WITH TIME ZONE NOT NULL
+    transaction_from_dts TIMESTAMP(6) WITH TIME ZONE NOT NULL
+    transaction_to_dts   TIMESTAMP(6) WITH TIME ZONE NOT NULL
+    is_current  BYTEINT NOT NULL DEFAULT 1
+    is_deleted          BYTEINT NOT NULL DEFAULT 0
 
 **Total: 8 columns**
 
 #### Tier 2: Extended Columns (Add When Justified)
 
-```sql
--- Version tracking (if humans need it)
-version_number      INTEGER
+    -- Version tracking (if humans need it)
+    version_number      INTEGER
 
--- ID type (if multiple identifier types exist)
-{entity}_id_type    VARCHAR(20)
+    -- ID type (if multiple identifier types exist)
+    {entity}_id_type    VARCHAR(20)
 
--- Direct references to Observability (for performance)
-change_event_id    BIGINT  -- FK to Observability.ChangeEvent_H
-lineage_id         BIGINT  -- FK to Observability.DataLineage_H
-quality_id        BIGINT  -- FK to Observability.DataQuality_H
+    -- Direct references to Observability (for performance)
+    change_event_id    BIGINT  -- FK to Observability.ChangeEvent_H
+    lineage_id         BIGINT  -- FK to Observability.DataLineage_H
+    quality_id        BIGINT  -- FK to Observability.DataQuality_H
 
--- Change detection (if needed in ETL)
-record_hash         VARCHAR(64)
-```
+    -- Change detection (if needed in ETL)
+    record_hash         VARCHAR(64)
 
 **Add selectively based on need**
 
 #### Tier 3: Offload to Observability (Recommended)
 
-```sql
--- Instead of in Domain table:
-created_by, updated_by, deleted_by, deleted_reason
-source_system, source_record_id, batch_id
-data_quality_score, quality_rule_failures
+    -- Instead of in Domain table:
+    created_by, updated_by, deleted_by, deleted_reason
+    source_system, source_record_id, batch_id
+    data_quality_score, quality_rule_failures
 
--- Store in Observability module:
-Observability.ChangeEvent_H    -- Who, when, why
-Observability.DataLineage_H    -- Source tracking
-Observability.DataQuality_H    -- Quality time-series
-```
+    -- Store in Observability module:
+    Observability.ChangeEvent_H    -- Who, when, why
+    Observability.DataLineage_H    -- Source tracking
+    Observability.DataQuality_H    -- Quality time-series
 
 ### 3.3 Column Overhead Comparison
 
 | Approach | Columns | Storage Impact | Join Needed |
-|----------|---------|----------------|-------------|
+| --- | --- | --- | --- |
 | **Core Only** | 8 | Minimal | Yes (via views) |
 | **Core + FK Refs** | 11 | Low | Yes (but fast) |
 | **Core + Extended** | 15-20 | Medium | Sometimes |
 | **Traditional (all in Domain)** | 20-25 | High | No |
 
+
 ### 3.4 Advocated Approach by Table Volume
 
 | Table Volume | Advocated Approach | Rationale |
-|--------------|-------------------|-----------|
+| --- | --- | --- |
 | **< 10M rows** | Core + Extended OK | Storage overhead acceptable |
 | **10M - 100M rows** | Core + FK Refs | Balance performance and storage |
 | **> 100M rows** | Core Only + Views | Minimize overhead |
@@ -382,18 +365,18 @@ Observability.DataQuality_H    -- Quality time-series
 
 ### 4.1 Why We Advocate Surrogate Keys
 
-**Advocated**: System-generated BIGINT surrogate keys
-**Alternative**: Natural keys as primary identifier
+**Advocated**: System-generated BIGINT surrogate keys **Alternative**: Natural keys as primary identifier
 
 #### Benefits of Surrogate Keys
 
 | Benefit | Description |
-|---------|-------------|
+| --- | --- |
 | **Stability** | Never changes, even if natural key changes |
 | **Performance** | BIGINT joins faster than VARCHAR |
 | **Simplicity** | Single column vs composite natural keys |
 | **Universality** | Works for all entity types |
 | **Cross-module** | Consistent FK pattern |
+
 
 ### 4.2 Surrogate Key Stability in History Tables
 
@@ -407,15 +390,13 @@ outputs, cross-module joins — hold FK references to the entity's surrogate. If
 surrogate changes between versions, those FK references become ambiguous: which
 version's value should be stored?
 
-```
-Illustrative example: Customer 'CUST-12345' with 3 SCD versions
-  Version 1 → party_id = 1
-  Version 2 → party_id = 1   ← same surrogate (correct — separate allocation)
-  Version 3 → party_id = 1   ← same surrogate (correct — separate allocation)
+    Illustrative example: Customer 'CUST-12345' with 3 SCD versions
+      Version 1 → party_id = 1
+      Version 2 → party_id = 1   ← same surrogate (correct — separate allocation)
+      Version 3 → party_id = 1   ← same surrogate (correct — separate allocation)
 
-  A transaction table holding party_id = 1 unambiguously identifies the customer
-  regardless of which version is current.
-```
+      A transaction table holding party_id = 1 unambiguously identifies the customer
+      regardless of which version is current.
 
 When surrogate allocation is managed separately, cross-module FK joins are stable
 and unambiguous regardless of how many SCD versions exist for an entity.
@@ -434,75 +415,69 @@ If adopting the Keymap pattern, the following templates apply.
 
 #### Keymap Table DDL
 
-```sql
--- One row per unique real-world entity.
--- IDENTITY fires here once per natural key — never on the _H table.
-CREATE TABLE {ProductName}_Domain.{Entity}_Keymap (
-    {entity}_id   BIGINT GENERATED ALWAYS AS IDENTITY NOT NULL,
-    {entity}_key  VARCHAR(50) CHARACTER SET LATIN NOT CASESPECIFIC NOT NULL,
-    source_system VARCHAR(50) CHARACTER SET LATIN NOT CASESPECIFIC,
-    created_dts   TIMESTAMP(6) WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP(6)
-)
-UNIQUE PRIMARY INDEX ({entity}_key);  -- UNIQUE PI: one row per natural key
+    -- One row per unique real-world entity.
+    -- IDENTITY fires here once per natural key — never on the _H table.
+    CREATE TABLE {ProductName}_Domain.{Entity}_Keymap (
+        {entity}_id   BIGINT GENERATED ALWAYS AS IDENTITY NOT NULL,
+        {entity}_key  VARCHAR(50) CHARACTER SET LATIN NOT CASESPECIFIC NOT NULL,
+        source_system VARCHAR(50) CHARACTER SET LATIN NOT CASESPECIFIC,
+        created_dts   TIMESTAMP(6) WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP(6)
+    )
+    UNIQUE PRIMARY INDEX ({entity}_key);  -- UNIQUE PI: one row per natural key
 
-COMMENT ON TABLE {ProductName}_Domain.{Entity}_Keymap IS
-'Keymap: one row per unique {entity}. Surrogate key (IDENTITY) generated here
-and referenced by {Entity}_H and all cross-domain FK columns. Natural key is
-{entity}_key from the source system.';
-COMMENT ON COLUMN {ProductName}_Domain.{Entity}_Keymap.{entity}_id IS
-'Surrogate key - generated exactly once per real-world entity. Stable across
-all SCD versions in {Entity}_H and across all modules that reference this entity.';
-COMMENT ON COLUMN {ProductName}_Domain.{Entity}_Keymap.{entity}_key IS
-'Natural business key from the source system - used to look up the stable surrogate.';
-```
+    COMMENT ON TABLE {ProductName}_Domain.{Entity}_Keymap IS
+    'Keymap: one row per unique {entity}. Surrogate key (IDENTITY) generated here
+    and referenced by {Entity}_H and all cross-domain FK columns. Natural key is
+    {entity}_key from the source system.';
+    COMMENT ON COLUMN {ProductName}_Domain.{Entity}_Keymap.{entity}_id IS
+    'Surrogate key - generated exactly once per real-world entity. Stable across
+    all SCD versions in {Entity}_H and across all modules that reference this entity.';
+    COMMENT ON COLUMN {ProductName}_Domain.{Entity}_Keymap.{entity}_key IS
+    'Natural business key from the source system - used to look up the stable surrogate.';
 
 #### History Table DDL
 
-```sql
--- {entity}_id is BIGINT NOT NULL — populated from the keymap (or equivalent
--- allocation mechanism) via JOIN. Never generated directly on this table.
--- Multiple rows with the same {entity}_id will exist (one per SCD version).
--- PRIMARY INDEX (non-unique) co-locates all versions on the same AMP,
--- making expire-and-insert SCD operations efficient.
-CREATE TABLE {ProductName}_Domain.{Entity}_H (
-    {entity}_id   BIGINT NOT NULL,         -- from Keymap — stable across versions
-    {entity}_key  VARCHAR(50) NOT NULL,    -- natural key repeated for convenience
-    -- ... temporal and business columns ...
-    PRIMARY INDEX ({entity}_id)            -- NUPI: multiple versions allowed
-);
+    -- {entity}_id is BIGINT NOT NULL — populated from the keymap (or equivalent
+    -- allocation mechanism) via JOIN. Never generated directly on this table.
+    -- Multiple rows with the same {entity}_id will exist (one per SCD version).
+    -- PRIMARY INDEX (non-unique) co-locates all versions on the same AMP,
+    -- making expire-and-insert SCD operations efficient.
+    CREATE TABLE {ProductName}_Domain.{Entity}_H (
+        {entity}_id   BIGINT NOT NULL,         -- from Keymap — stable across versions
+        {entity}_key  VARCHAR(50) NOT NULL,    -- natural key repeated for convenience
+        -- ... temporal and business columns ...
+        PRIMARY INDEX ({entity}_id)            -- NUPI: multiple versions allowed
+    );
 
-COMMENT ON COLUMN {ProductName}_Domain.{Entity}_H.{entity}_id IS
-'Surrogate key - allocated via surrogate key allocation strategy (see Advocated
-Data Management Standards Section 4). Stable across all SCD versions for the
-same real-world entity. Never generated directly on this table.';
-```
+    COMMENT ON COLUMN {ProductName}_Domain.{Entity}_H.{entity}_id IS
+    'Surrogate key - allocated via surrogate key allocation strategy (see Advocated
+    Data Management Standards Section 4). Stable across all SCD versions for the
+    same real-world entity. Never generated directly on this table.';
 
 #### Two-Step Load Pattern (Keymap approach)
 
-```sql
--- Step 1: Register any new natural keys (idempotent — WHERE NOT EXISTS)
-INSERT INTO {ProductName}_Domain.{Entity}_Keymap ({entity}_key, source_system)
-SELECT DISTINCT TRIM(s.NATURAL_KEY_COLUMN), 'SOURCE_SYSTEM_NAME'
-FROM {source_table} s
-WHERE NOT EXISTS (
-    SELECT 1 FROM {ProductName}_Domain.{Entity}_Keymap k
-    WHERE k.{entity}_key = TRIM(s.NATURAL_KEY_COLUMN)
-);
+    -- Step 1: Register any new natural keys (idempotent — WHERE NOT EXISTS)
+    INSERT INTO {ProductName}_Domain.{Entity}_Keymap ({entity}_key, source_system)
+    SELECT DISTINCT TRIM(s.NATURAL_KEY_COLUMN), 'SOURCE_SYSTEM_NAME'
+    FROM {source_table} s
+    WHERE NOT EXISTS (
+        SELECT 1 FROM {ProductName}_Domain.{Entity}_Keymap k
+        WHERE k.{entity}_key = TRIM(s.NATURAL_KEY_COLUMN)
+    );
 
--- Step 2: Populate history table using keymap JOIN
-INSERT INTO {ProductName}_Domain.{Entity}_H (
-    {entity}_id, {entity}_key, /* business columns */,
-    valid_from_dts, valid_to_dts, is_current, is_deleted
-)
-SELECT
-    k.{entity}_id,               -- stable surrogate from keymap
-    TRIM(s.NATURAL_KEY_COLUMN),
-    /* business columns */,
-    CURRENT_TIMESTAMP(6), TIMESTAMP '9999-12-31 23:59:59.999999+00:00', 1, 0
-FROM {source_table}                              s
-JOIN {ProductName}_Domain.{Entity}_Keymap        k
-    ON k.{entity}_key = TRIM(s.NATURAL_KEY_COLUMN);
-```
+    -- Step 2: Populate history table using keymap JOIN
+    INSERT INTO {ProductName}_Domain.{Entity}_H (
+        {entity}_id, {entity}_key, /* business columns */,
+        valid_from_dts, valid_to_dts, is_current, is_deleted
+    )
+    SELECT
+        k.{entity}_id,               -- stable surrogate from keymap
+        TRIM(s.NATURAL_KEY_COLUMN),
+        /* business columns */,
+        CURRENT_TIMESTAMP(6), TIMESTAMP '9999-12-31 23:59:59.999999+00:00', 1, 0
+    FROM {source_table}                              s
+    JOIN {ProductName}_Domain.{Entity}_Keymap        k
+        ON k.{entity}_key = TRIM(s.NATURAL_KEY_COLUMN);
 
 #### Cross-Entity Foreign Keys
 
@@ -510,74 +485,69 @@ Regardless of the surrogate key allocation mechanism chosen, all FK references
 between domain entities should point to the **stable surrogate**, not to a specific
 row in the `_H` table, to ensure FK joins are unambiguous across SCD versions.
 
-```sql
--- FK columns in other entities reference the stable surrogate
-CREATE TABLE {ProductName}_Domain.Order_H (
-    order_id    BIGINT NOT NULL,
-    party_id    BIGINT,     -- FK to Party stable surrogate (e.g. via Party_Keymap)
-    product_id  BIGINT,     -- FK to Product stable surrogate
-    -- ...
-);
-```
+    -- FK columns in other entities reference the stable surrogate
+    CREATE TABLE {ProductName}_Domain.Order_H (
+        order_id    BIGINT NOT NULL,
+        party_id    BIGINT,     -- FK to Party stable surrogate (e.g. via Party_Keymap)
+        product_id  BIGINT,     -- FK to Product stable surrogate
+        -- ...
+    );
 
 ### 4.4 Reference and Lookup Table Exemption
 
-The surrogate key stability requirement applies to entities whose surrogate is
-**referenced as a foreign key by other tables**. Reference and lookup tables, as
+The surrogate key stability requirement applies to entities whose surrogate is **referenced as a foreign key by other tables**. Reference and lookup tables, as
 well as detail/child entities that are never themselves FK-referenced, do not need a
 separate allocation mechanism — a simple IDENTITY column directly on the `_H` table
 is sufficient, since no external table holds a reference to their surrogate across
 SCD versions.
 
-```
-Stable allocation required           Simple IDENTITY on _H acceptable
-----------------------------------   ------------------------------------------
-Party   (FK target of Order)         Reference tables  (e.g. LoanPurpose_R)
-Order   (FK target of LineItem)      Lookup tables     (e.g. StatusCode_R)
-Product (FK target of Order)         Detail/child entities with no FK dependants
-                                     (e.g. CustomerContact, PropertyRisk)
-```
+    Stable allocation required           Simple IDENTITY on _H acceptable
+    ----------------------------------   ------------------------------------------
+    Party   (FK target of Order)         Reference tables  (e.g. LoanPurpose_R)
+    Order   (FK target of LineItem)      Lookup tables     (e.g. StatusCode_R)
+    Product (FK target of Order)         Detail/child entities with no FK dependants
+                                         (e.g. CustomerContact, PropertyRisk)
 
 **Rule**: Does any other table hold a FK column pointing to this entity's surrogate?
+
 - YES → A surrogate allocation strategy is recommended to ensure FK stability across SCD versions
-- NO  → Simple IDENTITY on `_H` is sufficient
+- NO → Simple IDENTITY on `_H` is sufficient
+
 
 ### 4.5 Surrogate Key Allocation Decision Tree
 
-```
-START: Is this entity's surrogate referenced as a FK by any other table?
-|
-+-- YES --> Surrogate allocation strategy required
-|           Options (choose one):
-|           a) Keymap pattern (recommended in this document)
-|           b) Organisation's existing central key allocation standard
-|           c) Database sequence with natural key constraint on _H
-|           Key principle: the surrogate must be stable across SCD versions
-|
-+-- NO  --> Reference/lookup table or detail entity: IDENTITY on _H is acceptable
-            - {entity}_id = BIGINT GENERATED ALWAYS AS IDENTITY on _H
-            - Single-step INSERT; no prior allocation step needed
-            - Document explicitly that this entity is not a FK target
-```
+    START: Is this entity's surrogate referenced as a FK by any other table?
+    |
+    +-- YES --> Surrogate allocation strategy required
+    |           Options (choose one):
+    |           a) Keymap pattern (recommended in this document)
+    |           b) Organisation's existing central key allocation standard
+    |           c) Database sequence with natural key constraint on _H
+    |           Key principle: the surrogate must be stable across SCD versions
+    |
+    +-- NO  --> Reference/lookup table or detail entity: IDENTITY on _H is acceptable
+                - {entity}_id = BIGINT GENERATED ALWAYS AS IDENTITY on _H
+                - Single-step INSERT; no prior allocation step needed
+                - Document explicitly that this entity is not a FK target
 
 ### 4.6 When Natural Keys Are Acceptable as the Surrogate
 
 **Use natural key as surrogate when:**
+
 - Natural key is truly immutable
 - Natural key is single column
 - Natural key is numeric (not VARCHAR)
 - Business strongly prefers it
 
+
 **Example**: Product SKU that never changes
 
-```sql
-CREATE TABLE Product_H (
-    product_id BIGINT NOT NULL,  -- Still use surrogate internally
-    sku        VARCHAR(20) NOT NULL,
-    -- ...
-    PRIMARY INDEX (product_id)
-);
-```
+    CREATE TABLE Product_H (
+        product_id BIGINT NOT NULL,  -- Still use surrogate internally
+        sku        VARCHAR(20) NOT NULL,
+        -- ...
+        PRIMARY INDEX (product_id)
+    );
 
 ---
 
@@ -585,13 +555,12 @@ CREATE TABLE Product_H (
 
 ### 5.1 Why We Advocate Soft Deletes
 
-**Hard Delete**: `DELETE FROM Party_H WHERE party_id = 1001`
-**Soft Delete**: `UPDATE Party_H SET is_deleted = 1 WHERE party_id = 1001`
+**Hard Delete**: `DELETE FROM Party_H WHERE party_id = 1001` **Soft Delete**: `UPDATE Party_H SET is_deleted = 1 WHERE party_id = 1001`
 
 #### Benefits for AI-Native Data Products
 
 | Benefit | Description |
-|---------|-------------|
+| --- | --- |
 | **Audit trail** | Complete history preserved |
 | **Explainability** | "Why did model predict X?" requires historical state |
 | **Regulatory compliance** | GDPR, CCPA require audit trails |
@@ -599,196 +568,351 @@ CREATE TABLE Product_H (
 | **Analytics** | Churn analysis, deletion patterns |
 | **ML features** | "Was customer deleted" is a feature |
 
+
 ### 5.2 Advocated Soft Delete Implementation
 
-```sql
--- Core column
-is_deleted BYTEINT NOT NULL DEFAULT 0
-    COMMENT '0 = Active, 1 = Soft deleted'
+    -- Core column
+    is_deleted BYTEINT NOT NULL DEFAULT 0
+        COMMENT '0 = Active, 1 = Soft deleted'
 
--- Optional: Store deletion details in Domain table
-deleted_by VARCHAR(100)
-    COMMENT 'User/system that soft deleted this record'
-deleted_dts TIMESTAMP(6) WITH TIME ZONE
-    COMMENT 'When this record was soft deleted'
-deleted_reason VARCHAR(500)
-    COMMENT 'Reason for soft delete (GDPR, data quality, etc.)'
+    -- Optional: Store deletion details in Domain table
+    deleted_by VARCHAR(100)
+        COMMENT 'User/system that soft deleted this record'
+    deleted_dts TIMESTAMP(6) WITH TIME ZONE
+        COMMENT 'When this record was soft deleted'
+    deleted_reason VARCHAR(500)
+        COMMENT 'Reason for soft delete (GDPR, data quality, etc.)'
 
--- Better: Store deletion details in Observability
--- (see Section 6)
-```
+    -- Better: Store deletion details in Observability
+    -- (see Section 7)
 
 ### 5.3 Soft Delete Operation
 
-```sql
--- Step 1: Close out current version
-UPDATE Party_H
-SET valid_to_dts = CURRENT_TIMESTAMP(6),
-    transaction_to_dts = CURRENT_TIMESTAMP(6),
-    is_current = 0
-WHERE party_id = 1001
-  AND is_current = 1;
+    -- Step 1: Close out current version
+    UPDATE Party_H
+    SET valid_to_dts = CURRENT_TIMESTAMP(6),
+        transaction_to_dts = CURRENT_TIMESTAMP(6),
+        is_current = 0
+    WHERE party_id = 1001
+      AND is_current = 1;
 
--- Step 2: Insert soft-deleted version
-INSERT INTO Party_H (
-    party_id, party_key, legal_name,
-    valid_from_dts, valid_to_dts,
-    transaction_from_dts, transaction_to_dts,
-    is_current, is_deleted
-) VALUES (
-    1001, 'CUST-12345', 'Jane Smith',
-    CURRENT_TIMESTAMP(6),  -- Deleted as of now
-    TIMESTAMP '9999-12-31 23:59:59.999999+00:00',
-    CURRENT_TIMESTAMP(6),
-    TIMESTAMP '9999-12-31 23:59:59.999999+00:00',
-    1,  -- is_current = 1 (this IS the current state: deleted)
-    1   -- is_deleted = 1
-);
+    -- Step 2: Insert soft-deleted version
+    INSERT INTO Party_H (
+        party_id, party_key, legal_name,
+        valid_from_dts, valid_to_dts,
+        transaction_from_dts, transaction_to_dts,
+        is_current, is_deleted
+    ) VALUES (
+        1001, 'CUST-12345', 'Jane Smith',
+        CURRENT_TIMESTAMP(6),  -- Deleted as of now
+        TIMESTAMP '9999-12-31 23:59:59.999999+00:00',
+        CURRENT_TIMESTAMP(6),
+        TIMESTAMP '9999-12-31 23:59:59.999999+00:00',
+        1,  -- is_current = 1 (this IS the current state: deleted)
+        1   -- is_deleted = 1
+    );
 
--- Track deletion details in Observability
-INSERT INTO Observability.ChangeEvent_H (
-    entity_type, entity_id, change_type,
-    changed_by, changed_dts, change_reason
-) VALUES (
-    'PARTY', 1001, 'DELETE',
-    'DELETE_PROCESS', CURRENT_TIMESTAMP(6), 'GDPR Right to be Forgotten'
-);
-```
+    -- Track deletion details in Observability
+    INSERT INTO Observability.ChangeEvent_H (
+        entity_type, entity_id, change_type,
+        changed_by, changed_dts, change_reason
+    ) VALUES (
+        'PARTY', 1001, 'DELETE',
+        'DELETE_PROCESS', CURRENT_TIMESTAMP(6), 'GDPR Right to be Forgotten'
+    );
 
 ### 5.4 Querying with Soft Deletes
 
-```sql
--- Current active records only (most common)
-SELECT * FROM Party_H
-WHERE is_current = 1
-  AND is_deleted = 0;
+    -- Current active records only (most common)
+    SELECT * FROM Party_H
+    WHERE is_current = 1
+      AND is_deleted = 0;
 
--- Include deleted records
-SELECT * FROM Party_H
-WHERE is_current = 1;
+    -- Include deleted records
+    SELECT * FROM Party_H
+    WHERE is_current = 1;
 
--- Only deleted records
-SELECT * FROM Party_H
-WHERE is_current = 1
-  AND is_deleted = 1;
-```
+    -- Only deleted records
+    SELECT * FROM Party_H
+    WHERE is_current = 1
+      AND is_deleted = 1;
 
 ### 5.5 When Hard Deletes Are Acceptable
 
 **Use hard deletes when:**
+
 - No regulatory audit requirement
 - No ML feature dependency
 - No analytics on deletion patterns
 - Storage constraints are critical
 - Data truly has no future value
 
+
 **Example**: Temporary staging data, test data
 
 ---
 
-## 6. Observability Offload Pattern
+## 6. Access Layer
 
-### 6.1 The Normalization Principle
+### 6.1 Why We Advocate Reading Through Views
+
+**Traditional Approach**: Consumers — analysts, applications, BI
+tools, agents — read tables directly, managing lock posture and
+column projection in every query.
+
+**Advocated Approach**: Tables are not the consumer surface.
+Every table that is read by anything other than its load process
+and DBAs is fronted by a view. Consumers read the view; the table
+is private.
+
+#### Key Benefits for AI-Native Data Products
+
+| Concern                        | Direct table reads          | Read through views      |
+| ------------------------------ | --------------------------- | ----------------------- |
+| **Concurrent loads**           | ⚠️ Read can block load      | ✅ Read is non-blocking |
+| **Lock posture consistency**   | ⚠️ Per-query, easy to omit  | ✅ Centralised in view  |
+| **Agent discoverability**      | ⚠️ Physical schema exposed  | ✅ Stable contract      |
+| **Permission management**      | ⚠️ Coupled to physical      | ✅ Decoupled            |
+| **Refactoring physical layer** | ❌ Breaks every consumer    | ✅ View absorbs change  |
+| **Schema documentation**       | ⚠️ Scattered                | ✅ Co-located in view   |
+
+The view layer is the **stable contract** between physical data
+and every consumer. As long as the contract holds, the underlying
+table can be re-partitioned, re-indexed, re-located, or
+re-modelled without breaking a single consumer. For AI-Native
+Data Products specifically, this stability is what allows an
+agent to learn a data product once and continue to operate
+correctly as its physical implementation evolves.
+
+### 6.2 Defer to the Object Placement Standard
+
+This document is deliberately silent on **where** tables and
+views are placed, **how** containers are named, and **how**
+access is granted across them. Those decisions are governed by a
+separate, layered standards system:
+
+| Document                                                | Role                                                                                                       |
+| ------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| **Object Placement Standard — Interface Specification** | Platform-agnostic contract. Defines the eight required sections any conforming placement standard must declare. |
+| **Object Placement Standard — Platform Implementation** | A conforming implementation for a specific platform (e.g. Teradata). Declares concrete naming, separation, view-tier architecture, access model, and validation procedure. |
+
+This document **advocates** access through views. The Object
+Placement Standard **prescribes** how that access is structured
+on a given platform. The split is intentional:
+
+- **Different organisations have different conventions.** Some
+  separate tables and views into distinct containers; some
+  co-locate them; some apply a layered zone model. All can be
+  conformant.
+- **The agent contract must be portable.** An AI-Native Data
+  Product agent reads a conforming Object Placement Standard
+  before generating any DDL. It does not assume — it reads, it
+  derives, it validates. The contract is the same shape on every
+  platform; the implementation differs.
+- **This document advocates patterns; the Object Placement
+  Standard prescribes structure.** Conflating the two would force
+  every reader to either adopt a single naming convention or
+  rewrite parts of this document — neither of which is
+  appropriate for an advocacy document.
+
+#### Agent and Builder Behaviour
+
+A data product builder, or an agent generating DDL within a data
+product, **must locate a conforming Object Placement Standard
+implementation before generating any object**. The Interface
+Specification defines the priority order for locating it:
+
+1. An explicit file path provided in conversation or project
+   instructions
+2. A skill file at a well-known path (e.g.
+   `/mnt/skills/user/object-placement/SKILL.md`)
+3. A file matching `Object_Placement_Standard*.md` in project
+   context
+4. **If none are present:** halt and ask the user
+
+A builder must never default to a placement convention,
+substitute its own assumption, or fall back to "the most common
+pattern". If the standard is absent, the correct response is to
+ask, not to guess.
+
+### 6.3 What This Document Continues to Cover
+
+The Object Placement Standard governs container structure,
+naming, separation, and access. This document continues to
+advocate **logical patterns** that are independent of placement:
+
+- Bi-temporal columns and their semantics (Section 2)
+- Column tiering and offload to Observability (Section 3)
+- Surrogate key strategy and the Keymap pattern (Section 4)
+- Soft-delete semantics (Section 5)
+- Observability offload pattern (Section 7)
+- Timezone handling (Section 8)
+- Data quality scoring (Section 9)
+- Audit trail strategy (Section 10)
+
+These patterns are **expressed in DDL** that the Object Placement
+Standard then places into the appropriate containers. The two
+standards compose: this document advocates *what* a `Customer_H`
+table contains; the Object Placement Standard determines *which
+container* `Customer_H` and its fronting view are placed in, what
+they are named, and how they are accessed.
+
+#### Worked Example of the Composition
+
+A `Customer_H` table designed under this document has bi-temporal
+columns (Section 2), a stable surrogate from a Keymap (Section
+4), and a soft-delete flag (Section 5). The Object Placement
+Standard then determines:
+
+- The container the table is placed in (e.g. a strict-separation
+  Teradata implementation places it in a `_T` container)
+- The container the fronting locking view is placed in (e.g. the
+  matching `_V` container under strict separation, or the same
+  container under co-location)
+- The exact name of each container, derived from the standard's
+  `derive_container()` function
+- The access grants and any implied grants required by the
+  separation architecture
+- The validation procedure that confirms placement after
+  deployment
+
+Neither document is complete on its own. Together they describe a
+fully-specified data product.
+
+### 6.4 Why This Is Agent-Friendly
+
+The split between *what to design* (this document) and *where to
+place it* (the Object Placement Standard) is what makes the
+combined system robust under agent operation. Three properties
+follow:
+
+**Portability across customers.** An agent that builds data
+products for multiple customers does not carry hard-coded
+placement assumptions. It carries a contract — read the
+Placement Standard, call its derivation function, run its
+validation procedure — and renders correctly into whatever
+convention the customer has chosen.
+
+**Stability under physical change.** A customer reorganising
+their container hierarchy revises one document — their Object
+Placement Standard. Every data product designed under this
+document continues to apply unchanged.
+
+**Independent evolution.** This document evolves as data
+management practices evolve (new bi-temporal patterns, new
+quality scoring approaches). Placement standards evolve as
+platform capabilities evolve (new container types, new access
+mechanisms). Neither blocks the other.
+
+### 6.5 Reference
+
+| Document                                                | Location                                                                                                            |
+| ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| **Object Placement Standard — Interface Specification** | [`platform-standards/Object_Placement_Standard_Spec.md`](../platform-standards/Object_Placement_Standard_Spec.md) — platform-agnostic; the contract |
+| **Teradata reference implementation**                   | `Object_Placement_Standard_Teradata.md` — conforming implementation for Teradata; distributed separately |
+
+Implementations for other platforms (Snowflake, BigQuery,
+Databricks, etc.) follow the same Interface Specification with
+platform-appropriate constructs. Any organisation may author its
+own conforming implementation that reflects local conventions.
+
+---
+
+## 7. Observability Offload Pattern
+
+### 7.1 The Normalization Principle
 
 **Problem**: Storing audit/lineage/quality data in Domain tables duplicates data across millions of rows
 
 **Advocated Solution**: Store once in Observability module, join when needed
 
-### 6.2 Observability Module Tables
+### 7.2 Observability Module Tables
 
 #### ChangeEvent_H (Audit Trail)
 
-```sql
-CREATE TABLE Observability.ChangeEvent_H (
-    change_event_id     BIGINT NOT NULL,
-    entity_type         VARCHAR(50) NOT NULL,  -- 'PARTY', 'PRODUCT', etc.
-    entity_id          BIGINT NOT NULL,
-    change_type         VARCHAR(20) NOT NULL,  -- 'INSERT', 'UPDATE', 'DELETE'
-    changed_by          VARCHAR(100) NOT NULL,
-    changed_dts         TIMESTAMP(6) WITH TIME ZONE NOT NULL,
-    change_reason       VARCHAR(500),
-    changed_columns     VARCHAR(2000),  -- JSON array of changed columns
-    old_values_json     JSON,
-    new_values_json     JSON,
-    PRIMARY INDEX (entity_id, changed_dts)
-)
-PARTITION BY RANGE_N(
-    changed_dts BETWEEN DATE '2020-01-01' AND DATE '2030-12-31' 
-    EACH INTERVAL '1' MONTH
-);
-```
+    CREATE TABLE Observability.ChangeEvent_H (
+        change_event_id     BIGINT NOT NULL,
+        entity_type         VARCHAR(50) NOT NULL,  -- 'PARTY', 'PRODUCT', etc.
+        entity_id          BIGINT NOT NULL,
+        change_type         VARCHAR(20) NOT NULL,  -- 'INSERT', 'UPDATE', 'DELETE'
+        changed_by          VARCHAR(100) NOT NULL,
+        changed_dts         TIMESTAMP(6) WITH TIME ZONE NOT NULL,
+        change_reason       VARCHAR(500),
+        changed_columns     VARCHAR(2000),  -- JSON array of changed columns
+        old_values_json     JSON,
+        new_values_json     JSON,
+        PRIMARY INDEX (entity_id, changed_dts)
+    )
+    PARTITION BY RANGE_N(
+        changed_dts BETWEEN DATE '2020-01-01' AND DATE '2030-12-31'
+        EACH INTERVAL '1' MONTH
+    );
 
 #### DataLineage_H (Source Tracking)
 
-```sql
-CREATE TABLE Observability.DataLineage_H (
-    lineage_id         BIGINT NOT NULL,
-    entity_type         VARCHAR(50) NOT NULL,
-    entity_id          BIGINT NOT NULL,
-    source_system       VARCHAR(50) NOT NULL,
-    source_record_id    VARCHAR(100),
-    batch_id            VARCHAR(50),
-    loaded_dts          TIMESTAMP(6) WITH TIME ZONE NOT NULL,
-    extraction_dts      TIMESTAMP(6) WITH TIME ZONE,
-    transformation_name VARCHAR(128),
-    lineage_metadata_json JSON,
-    PRIMARY INDEX (entity_id)
-);
-```
+    CREATE TABLE Observability.DataLineage_H (
+        lineage_id         BIGINT NOT NULL,
+        entity_type         VARCHAR(50) NOT NULL,
+        entity_id          BIGINT NOT NULL,
+        source_system       VARCHAR(50) NOT NULL,
+        source_record_id    VARCHAR(100),
+        batch_id            VARCHAR(50),
+        loaded_dts          TIMESTAMP(6) WITH TIME ZONE NOT NULL,
+        extraction_dts      TIMESTAMP(6) WITH TIME ZONE,
+        transformation_name VARCHAR(128),
+        lineage_metadata_json JSON,
+        PRIMARY INDEX (entity_id)
+    );
 
 #### DataQuality_H (Quality Time-Series)
 
-```sql
-CREATE TABLE Observability.DataQuality_H (
-    quality_id         BIGINT NOT NULL,
-    entity_type         VARCHAR(50) NOT NULL,
-    entity_id          BIGINT NOT NULL,
-    evaluated_dts       TIMESTAMP(6) WITH TIME ZONE NOT NULL,
-    quality_score       DECIMAL(3,2) NOT NULL,
-    rule_results_json   JSON,  -- Array of {rule_id, passed, message}
-    PRIMARY INDEX (entity_id, evaluated_dts)
-)
-PARTITION BY RANGE_N(
-    evaluated_dts BETWEEN DATE '2024-01-01' AND DATE '2030-12-31' 
-    EACH INTERVAL '1' MONTH
-);
-```
+    CREATE TABLE Observability.DataQuality_H (
+        quality_id         BIGINT NOT NULL,
+        entity_type         VARCHAR(50) NOT NULL,
+        entity_id          BIGINT NOT NULL,
+        evaluated_dts       TIMESTAMP(6) WITH TIME ZONE NOT NULL,
+        quality_score       DECIMAL(3,2) NOT NULL,
+        rule_results_json   JSON,  -- Array of {rule_id, passed, message}
+        PRIMARY INDEX (entity_id, evaluated_dts)
+    )
+    PARTITION BY RANGE_N(
+        evaluated_dts BETWEEN DATE '2024-01-01' AND DATE '2030-12-31'
+        EACH INTERVAL '1' MONTH
+    );
 
-### 6.3 Two Join Approaches
+### 7.3 Two Join Approaches
 
 #### Approach 1: Surrogate Key References (Fastest)
 
 **Domain table includes FK to Observability:**
 
-```sql
-CREATE TABLE Party_H (
-    party_id BIGINT NOT NULL,
-    -- ... core columns ...
-    
-    -- Optional: Direct references for performance
-    change_event_id BIGINT,  -- FK to most recent ChangeEvent
-    lineage_id BIGINT,       -- FK to current DataLineage
-    quality_id BIGINT,       -- FK to latest DataQuality
-    
-    FOREIGN KEY (change_event_id) 
-        REFERENCES Observability.ChangeEvent_H(change_event_id),
-    FOREIGN KEY (lineage_id) 
-        REFERENCES Observability.DataLineage_H(lineage_id),
-    FOREIGN KEY (quality_id) 
-        REFERENCES Observability.DataQuality_H(quality_id)
-);
+    CREATE TABLE Party_H (
+        party_id BIGINT NOT NULL,
+        -- ... core columns ...
+  
+        -- Optional: Direct references for performance
+        change_event_id BIGINT,  -- FK to most recent ChangeEvent
+        lineage_id BIGINT,       -- FK to current DataLineage
+        quality_id BIGINT,       -- FK to latest DataQuality
+  
+        FOREIGN KEY (change_event_id)
+            REFERENCES Observability.ChangeEvent_H(change_event_id),
+        FOREIGN KEY (lineage_id)
+            REFERENCES Observability.DataLineage_H(lineage_id),
+        FOREIGN KEY (quality_id)
+            REFERENCES Observability.DataQuality_H(quality_id)
+    );
 
--- Query: Fast direct join
-SELECT p.*, ce.changed_by, dl.source_system, dq.quality_score
-FROM Party_H p
-LEFT JOIN Observability.ChangeEvent_H ce 
-    ON ce.change_event_id = p.change_event_id
-LEFT JOIN Observability.DataLineage_H dl 
-    ON dl.lineage_id = p.lineage_id
-LEFT JOIN Observability.DataQuality_H dq 
-    ON dq.quality_id = p.quality_id
-WHERE p.is_current = 1;
-```
+    -- Query: Fast direct join
+    SELECT p.*, ce.changed_by, dl.source_system, dq.quality_score
+    FROM Party_H p
+    LEFT JOIN Observability.ChangeEvent_H ce
+        ON ce.change_event_id = p.change_event_id
+    LEFT JOIN Observability.DataLineage_H dl
+        ON dl.lineage_id = p.lineage_id
+    LEFT JOIN Observability.DataQuality_H dq
+        ON dq.quality_id = p.quality_id
+    WHERE p.is_current = 1;
 
 **Overhead**: 3 BIGINT columns (24 bytes) vs 15+ columns (500+ bytes)
 
@@ -796,263 +920,247 @@ WHERE p.is_current = 1;
 
 **Domain table has NO FK, join on entity_id + entity_type:**
 
-```sql
-CREATE TABLE Party_H (
-    party_id BIGINT NOT NULL,
-    -- ... core columns only (8 columns) ...
-);
+    CREATE TABLE Party_H (
+        party_id BIGINT NOT NULL,
+        -- ... core columns only (8 columns) ...
+    );
 
--- Query: Join by entity reference
-SELECT p.*, ce.changed_by, dl.source_system, dq.quality_score
-FROM Party_H p
-LEFT JOIN (
-    SELECT entity_id, changed_by, changed_dts,
-           ROW_NUMBER() OVER (PARTITION BY entity_id ORDER BY changed_dts DESC) AS rn
-    FROM Observability.ChangeEvent_H
-    WHERE entity_type = 'PARTY'
-) ce ON ce.entity_id = p.party_id AND ce.rn = 1
-LEFT JOIN Observability.DataLineage_H dl
-    ON dl.entity_type = 'PARTY' AND dl.entity_id = p.party_id
-LEFT JOIN (
-    SELECT entity_id, quality_score, evaluated_dts,
-           ROW_NUMBER() OVER (PARTITION BY entity_id ORDER BY evaluated_dts DESC) AS rn
-    FROM Observability.DataQuality_H
-    WHERE entity_type = 'PARTY'
-) dq ON dq.entity_id = p.party_id AND dq.rn = 1
-WHERE p.is_current = 1;
-```
+    -- Query: Join by entity reference
+    SELECT p.*, ce.changed_by, dl.source_system, dq.quality_score
+    FROM Party_H p
+    LEFT JOIN (
+        SELECT entity_id, changed_by, changed_dts,
+               ROW_NUMBER() OVER (PARTITION BY entity_id ORDER BY changed_dts DESC) AS rn
+        FROM Observability.ChangeEvent_H
+        WHERE entity_type = 'PARTY'
+    ) ce ON ce.entity_id = p.party_id AND ce.rn = 1
+    LEFT JOIN Observability.DataLineage_H dl
+        ON dl.entity_type = 'PARTY' AND dl.entity_id = p.party_id
+    LEFT JOIN (
+        SELECT entity_id, quality_score, evaluated_dts,
+               ROW_NUMBER() OVER (PARTITION BY entity_id ORDER BY evaluated_dts DESC) AS rn
+        FROM Observability.DataQuality_H
+        WHERE entity_type = 'PARTY'
+    ) dq ON dq.entity_id = p.party_id AND dq.rn = 1
+    WHERE p.is_current = 1;
 
 **Overhead**: 0 additional columns, join on indexed columns
 
-### 6.4 Pre-Joined Views for Agent Access
+### 7.4 Pre-Joined Views for Agent Access
 
-```sql
--- Create view to simplify agent queries
-CREATE VIEW Party_Complete AS
-SELECT 
-    p.party_id, p.party_key, p.legal_name,
-    p.valid_from_dts, p.valid_to_dts,
-    ce.changed_by AS last_changed_by,
-    ce.changed_dts AS last_changed_dts,
-    ce.change_reason,
-    dl.source_system,
-    dl.batch_id,
-    dq.quality_score,
-    dq.evaluated_dts AS quality_evaluated_dts
-FROM Party_H p
-LEFT JOIN Observability.ChangeEvent_H ce 
-    ON ce.change_event_id = p.change_event_id  -- If using FK approach
-LEFT JOIN Observability.DataLineage_H dl 
-    ON dl.lineage_id = p.lineage_id
-LEFT JOIN Observability.DataQuality_H dq 
-    ON dq.quality_id = p.quality_id
-WHERE p.is_current = 1;
+    -- Create view to simplify agent queries
+    CREATE VIEW Party_Complete AS
+    SELECT
+        p.party_id, p.party_key, p.legal_name,
+        p.valid_from_dts, p.valid_to_dts,
+        ce.changed_by AS last_changed_by,
+        ce.changed_dts AS last_changed_dts,
+        ce.change_reason,
+        dl.source_system,
+        dl.batch_id,
+        dq.quality_score,
+        dq.evaluated_dts AS quality_evaluated_dts
+    FROM Party_H p
+    LEFT JOIN Observability.ChangeEvent_H ce
+        ON ce.change_event_id = p.change_event_id  -- If using FK approach
+    LEFT JOIN Observability.DataLineage_H dl
+        ON dl.lineage_id = p.lineage_id
+    LEFT JOIN Observability.DataQuality_H dq
+        ON dq.quality_id = p.quality_id
+    WHERE p.is_current = 1;
 
--- Agent query (simple)
-SELECT * FROM Party_Complete WHERE party_key = 'CUST-12345';
-```
+    -- Agent query (simple)
+    SELECT * FROM Party_Complete WHERE party_key = 'CUST-12345';
 
-### 6.5 Advocated Approach by Scenario
+### 7.5 Advocated Approach by Scenario
 
 | Scenario | Recommended Approach |
-|----------|---------------------|
+| --- | --- |
 | **High-volume tables (>100M rows)** | No FK, join by entity_id, use views |
 | **Medium-volume (10M-100M)** | FK references for performance |
 | **Low-volume (<10M)** | Either approach acceptable |
 | **Agent-heavy workload** | Pre-joined views essential |
 | **Storage-constrained** | No FK, offload everything |
 
-### 6.6 Benefits Quantification
+
+### 7.6 Benefits Quantification
 
 **Example: 50M row Party table**
 
 | Approach | Domain Table Size | Join Performance | Complexity |
-|----------|-------------------|------------------|------------|
+| --- | --- | --- | --- |
 | **Traditional (all in Domain)** | ~10 GB | N/A (no join) | Low |
 | **Core + FK refs** | ~6 GB | Fast (direct FK) | Medium |
 | **Core only + views** | ~4 GB | Fast (indexed) | Medium |
+
 
 **Storage savings**: 40-60% while maintaining query performance
 
 ---
 
-## 7. Timezone Handling
+## 8. Timezone Handling
 
-### 7.1 Why We Advocate TIMESTAMP WITH TIME ZONE
+### 8.1 Why We Advocate TIMESTAMP WITH TIME ZONE
 
-**Problem**: Global enterprises operate across multiple timezones
-**Impact**: Temporal accuracy, regulatory compliance, cross-region analysis
+**Problem**: Global enterprises operate across multiple timezones **Impact**: Temporal accuracy, regulatory compliance, cross-region analysis
 
-### 7.2 Advocated Standard
+### 8.2 Advocated Standard
 
 **Always use `TIMESTAMP(6) WITH TIME ZONE` for all temporal columns**
 
-```sql
--- ADVOCATED
-valid_from_dts      TIMESTAMP(6) WITH TIME ZONE NOT NULL
-valid_to_dts        TIMESTAMP(6) WITH TIME ZONE NOT NULL
-transaction_from_dts TIMESTAMP(6) WITH TIME ZONE NOT NULL
-transaction_to_dts   TIMESTAMP(6) WITH TIME ZONE NOT NULL
+    -- ADVOCATED
+    valid_from_dts      TIMESTAMP(6) WITH TIME ZONE NOT NULL
+    valid_to_dts        TIMESTAMP(6) WITH TIME ZONE NOT NULL
+    transaction_from_dts TIMESTAMP(6) WITH TIME ZONE NOT NULL
+    transaction_to_dts   TIMESTAMP(6) WITH TIME ZONE NOT NULL
 
--- NOT RECOMMENDED
-valid_from_dts      TIMESTAMP(6) NOT NULL  -- Missing timezone
-```
+    -- NOT RECOMMENDED
+    valid_from_dts      TIMESTAMP(6) NOT NULL  -- Missing timezone
 
-### 7.3 Default Values with Timezone
+### 8.3 Default Values with Timezone
 
-```sql
--- Always include timezone in defaults
-DEFAULT TIMESTAMP '9999-12-31 23:59:59.999999+00:00'  -- UTC
+    -- Always include timezone in defaults
+    DEFAULT TIMESTAMP '9999-12-31 23:59:59.999999+00:00'  -- UTC
 
--- NOT
-DEFAULT TIMESTAMP '9999-12-31 23:59:59.999999'  -- Ambiguous
-```
+    -- NOT
+    DEFAULT TIMESTAMP '9999-12-31 23:59:59.999999'  -- Ambiguous
 
-### 7.4 Timezone Best Practices
+### 8.4 Timezone Best Practices
 
 | Practice | Recommendation |
-|----------|---------------|
+| --- | --- |
 | **Storage** | Always store in UTC (+00:00) |
 | **Display** | Convert to user's local timezone in application |
 | **Defaults** | Use UTC for all default timestamps |
 | **Queries** | Include explicit timezone in literals |
 | **Comparison** | Database handles timezone conversion automatically |
 
-### 7.5 Query Examples with Timezone
 
-```sql
--- Correct: Explicit timezone
-SELECT * FROM Party_H
-WHERE valid_from_dts >= TIMESTAMP '2024-01-01 00:00:00+00:00'
-  AND valid_from_dts < TIMESTAMP '2024-02-01 00:00:00+00:00';
+### 8.5 Query Examples with Timezone
 
--- Also correct: Database will convert to UTC
-SELECT * FROM Party_H
-WHERE valid_from_dts >= TIMESTAMP '2024-01-01 00:00:00-05:00'  -- EST
-  AND valid_from_dts < TIMESTAMP '2024-02-01 00:00:00-05:00';
+    -- Correct: Explicit timezone
+    SELECT * FROM Party_H
+    WHERE valid_from_dts >= TIMESTAMP '2024-01-01 00:00:00+00:00'
+      AND valid_from_dts < TIMESTAMP '2024-02-01 00:00:00+00:00';
 
--- Convert to different timezone for display
-SELECT party_key,
-       valid_from_dts AT TIME ZONE 'America/New_York' AS valid_from_est,
-       valid_from_dts AT TIME ZONE 'Europe/London' AS valid_from_gmt
-FROM Party_H;
-```
+    -- Also correct: Database will convert to UTC
+    SELECT * FROM Party_H
+    WHERE valid_from_dts >= TIMESTAMP '2024-01-01 00:00:00-05:00'  -- EST
+      AND valid_from_dts < TIMESTAMP '2024-02-01 00:00:00-05:00';
 
-### 7.6 When TIMESTAMP (without timezone) Is Acceptable
+    -- Convert to different timezone for display
+    SELECT party_key,
+           valid_from_dts AT TIME ZONE 'America/New_York' AS valid_from_est,
+           valid_from_dts AT TIME ZONE 'Europe/London' AS valid_from_gmt
+    FROM Party_H;
+
+### 8.6 When TIMESTAMP (without timezone) Is Acceptable
 
 **Use TIMESTAMP without timezone only when:**
+
 - Data is purely local (single timezone, will never expand)
 - Regulatory requirement for specific timezone
 - Legacy system compatibility required
+
 
 **Document the timezone assumption explicitly**
 
 ---
 
-## 8. Data Quality Management
+## 9. Data Quality Management
 
-### 8.1 Advocated Quality Scoring Approach
+### 9.1 Advocated Quality Scoring Approach
 
 **Principle**: Agents need to assess data reliability before using it
 
-### 8.2 Quality Score Calculation
+### 9.2 Quality Score Calculation
 
 **Advocated**: 0.00-1.00 score based on validation rules
 
-```sql
--- Example: Party quality score
-quality_score = (
-    CASE WHEN legal_name IS NOT NULL THEN 0.20 ELSE 0 END +
-    CASE WHEN tax_identifier IS NOT NULL THEN 0.20 ELSE 0 END +
-    CASE WHEN email_address IS NOT NULL AND email_validated = 1 THEN 0.20 ELSE 0 END +
-    CASE WHEN phone_number IS NOT NULL AND phone_validated = 1 THEN 0.20 ELSE 0 END +
-    CASE WHEN address_complete = 1 THEN 0.20 ELSE 0 END
-)
-```
+    -- Example: Party quality score
+    quality_score = (
+        CASE WHEN legal_name IS NOT NULL THEN 0.20 ELSE 0 END +
+        CASE WHEN tax_identifier IS NOT NULL THEN 0.20 ELSE 0 END +
+        CASE WHEN email_address IS NOT NULL AND email_validated = 1 THEN 0.20 ELSE 0 END +
+        CASE WHEN phone_number IS NOT NULL AND phone_validated = 1 THEN 0.20 ELSE 0 END +
+        CASE WHEN address_complete = 1 THEN 0.20 ELSE 0 END
+    )
 
-### 8.3 Two Storage Approaches
+### 9.3 Two Storage Approaches
 
 #### Approach 1: Store Latest Score in Domain (Extended Column)
 
-```sql
-CREATE TABLE Party_H (
-    -- ... core columns ...
-    data_quality_score DECIMAL(3,2)
-        COMMENT 'Quality score 0.00-1.00 based on validation rules',
-    -- ...
-);
+    CREATE TABLE Party_H (
+        -- ... core columns ...
+        data_quality_score DECIMAL(3,2)
+            COMMENT 'Quality score 0.00-1.00 based on validation rules',
+        -- ...
+    );
 
--- Agent query
-SELECT party_key, legal_name, data_quality_score
-FROM Party_H
-WHERE is_current = 1
-  AND data_quality_score >= 0.75;  -- High quality only
-```
+    -- Agent query
+    SELECT party_key, legal_name, data_quality_score
+    FROM Party_H
+    WHERE is_current = 1
+      AND data_quality_score >= 0.75;  -- High quality only
 
-**Pros**: Simple, fast single-table queries
-**Cons**: Only latest score, no history, adds column overhead
+**Pros**: Simple, fast single-table queries **Cons**: Only latest score, no history, adds column overhead
 
 #### Approach 2: Store in Observability (Advocated)
 
-```sql
--- Store quality time-series in Observability
-INSERT INTO Observability.DataQuality_H (
-    entity_type, entity_id, evaluated_dts, quality_score,
-    rule_results_json
-) VALUES (
-    'PARTY', 1001, CURRENT_TIMESTAMP(6), 0.80,
-    JSON '{"rules": [
-        {"rule_id": "R01", "rule_name": "has_legal_name", "passed": true},
-        {"rule_id": "R02", "rule_name": "has_tax_id", "passed": true},
-        {"rule_id": "R03", "rule_name": "has_email", "passed": true},
-        {"rule_id": "R04", "rule_name": "has_phone", "passed": false}
-    ]}'
-);
+    -- Store quality time-series in Observability
+    INSERT INTO Observability.DataQuality_H (
+        entity_type, entity_id, evaluated_dts, quality_score,
+        rule_results_json
+    ) VALUES (
+        'PARTY', 1001, CURRENT_TIMESTAMP(6), 0.80,
+        JSON '{"rules": [
+            {"rule_id": "R01", "rule_name": "has_legal_name", "passed": true},
+            {"rule_id": "R02", "rule_name": "has_tax_id", "passed": true},
+            {"rule_id": "R03", "rule_name": "has_email", "passed": true},
+            {"rule_id": "R04", "rule_name": "has_phone", "passed": false}
+        ]}'
+    );
 
--- Agent query with quality filter
-SELECT p.party_key, p.legal_name, dq.quality_score
-FROM Party_H p
-INNER JOIN (
-    SELECT entity_id, quality_score,
-           ROW_NUMBER() OVER (PARTITION BY entity_id ORDER BY evaluated_dts DESC) AS rn
-    FROM Observability.DataQuality_H
-    WHERE entity_type = 'PARTY'
-) dq ON dq.entity_id = p.party_id AND dq.rn = 1
-WHERE p.is_current = 1
-  AND dq.quality_score >= 0.75;
-```
+    -- Agent query with quality filter
+    SELECT p.party_key, p.legal_name, dq.quality_score
+    FROM Party_H p
+    INNER JOIN (
+        SELECT entity_id, quality_score,
+               ROW_NUMBER() OVER (PARTITION BY entity_id ORDER BY evaluated_dts DESC) AS rn
+        FROM Observability.DataQuality_H
+        WHERE entity_type = 'PARTY'
+    ) dq ON dq.entity_id = p.party_id AND dq.rn = 1
+    WHERE p.is_current = 1
+      AND dq.quality_score >= 0.75;
 
-**Pros**: No Domain overhead, quality history, detailed rule results
-**Cons**: Requires join (mitigated by views)
+**Pros**: No Domain overhead, quality history, detailed rule results **Cons**: Requires join (mitigated by views)
 
-### 8.4 Advocated: Use Views for Agent Access
+### 9.4 Advocated: Use Views for Agent Access
 
-```sql
-CREATE VIEW Party_HighQuality AS
-SELECT p.party_id, p.party_key, p.legal_name,
-       dq.quality_score, dq.evaluated_dts,
-       dq.rule_results_json
-FROM Party_H p
-INNER JOIN (
-    SELECT entity_id, quality_score, evaluated_dts, rule_results_json,
-           ROW_NUMBER() OVER (PARTITION BY entity_id ORDER BY evaluated_dts DESC) AS rn
-    FROM Observability.DataQuality_H
-    WHERE entity_type = 'PARTY'
-) dq ON dq.entity_id = p.party_id AND dq.rn = 1
-WHERE p.is_current = 1
-  AND p.is_deleted = 0
-  AND dq.quality_score >= 0.75;
+    CREATE VIEW Party_HighQuality AS
+    SELECT p.party_id, p.party_key, p.legal_name,
+           dq.quality_score, dq.evaluated_dts,
+           dq.rule_results_json
+    FROM Party_H p
+    INNER JOIN (
+        SELECT entity_id, quality_score, evaluated_dts, rule_results_json,
+               ROW_NUMBER() OVER (PARTITION BY entity_id ORDER BY evaluated_dts DESC) AS rn
+        FROM Observability.DataQuality_H
+        WHERE entity_type = 'PARTY'
+    ) dq ON dq.entity_id = p.party_id AND dq.rn = 1
+    WHERE p.is_current = 1
+      AND p.is_deleted = 0
+      AND dq.quality_score >= 0.75;
 
--- Agent query (simple)
-SELECT * FROM Party_HighQuality WHERE party_key = 'CUST-12345';
-```
+    -- Agent query (simple)
+    SELECT * FROM Party_HighQuality WHERE party_key = 'CUST-12345';
 
-### 8.5 Quality Rule Framework
+### 9.5 Quality Rule Framework
 
 **Advocated**: Standard rule categories
 
 | Rule Category | Examples | Weight |
-|--------------|----------|--------|
+| --- | --- | --- |
 | **Completeness** | Required fields populated | 30% |
 | **Validity** | Format validation, range checks | 25% |
 | **Consistency** | Cross-field validation | 20% |
@@ -1061,113 +1169,104 @@ SELECT * FROM Party_HighQuality WHERE party_key = 'CUST-12345';
 
 ---
 
-## 9. Audit Trail Strategy
+## 10. Audit Trail Strategy
 
-### 9.1 Why Comprehensive Audit Trails
+### 10.1 Why Comprehensive Audit Trails
 
-**Regulatory**: GDPR, CCPA, SOX, HIPAA require audit trails
-**Explainability**: "Why did the model predict X?" requires historical context
-**Security**: Detect unauthorized changes
-**Debugging**: Trace data lineage and transformations
+**Regulatory**: GDPR, CCPA, SOX, HIPAA require audit trails **Explainability**: "Why did the model predict X?" requires historical context **Security**: Detect unauthorized changes **Debugging**: Trace data lineage and transformations
 
-### 9.2 Advocated Audit Approach
+### 10.2 Advocated Audit Approach
 
 **Store detailed audit in Observability.ChangeEvent_H**
 
-```sql
-CREATE TABLE Observability.ChangeEvent_H (
-    change_event_id    BIGINT NOT NULL,
-    entity_type         VARCHAR(50) NOT NULL,
-    entity_id          BIGINT NOT NULL,
-    change_type         VARCHAR(20) NOT NULL,  -- 'INSERT', 'UPDATE', 'DELETE'
-    
-    -- Who and when
-    changed_by          VARCHAR(100) NOT NULL,
-    changed_dts         TIMESTAMP(6) WITH TIME ZONE NOT NULL,
-    
-    -- What and why
-    change_reason       VARCHAR(500),
-    changed_columns     VARCHAR(2000),  -- JSON array: ["legal_name", "email"]
-    
-    -- Before and after
-    old_values_json     JSON,  -- {legal_name: "Jane Doe", email: "old@..."}
-    new_values_json     JSON,  -- {legal_name: "Jane Smith", email: "new@..."}
-    
-    -- Context
-    session_id          VARCHAR(100),
-    application_name VARCHAR(128),
-    ip_address          VARCHAR(50),
-    
-    PRIMARY INDEX (entity_id, changed_dts)
-)
-PARTITION BY RANGE_N(
-    changed_dts BETWEEN DATE '2020-01-01' AND DATE '2030-12-31' 
-    EACH INTERVAL '1' MONTH
-);
-```
+    CREATE TABLE Observability.ChangeEvent_H (
+        change_event_id    BIGINT NOT NULL,
+        entity_type         VARCHAR(50) NOT NULL,
+        entity_id          BIGINT NOT NULL,
+        change_type         VARCHAR(20) NOT NULL,  -- 'INSERT', 'UPDATE', 'DELETE'
+  
+        -- Who and when
+        changed_by          VARCHAR(100) NOT NULL,
+        changed_dts         TIMESTAMP(6) WITH TIME ZONE NOT NULL,
+  
+        -- What and why
+        change_reason       VARCHAR(500),
+        changed_columns     VARCHAR(2000),  -- JSON array: ["legal_name", "email"]
+  
+        -- Before and after
+        old_values_json     JSON,  -- {legal_name: "Jane Doe", email: "old@..."}
+        new_values_json     JSON,  -- {legal_name: "Jane Smith", email: "new@..."}
+  
+        -- Context
+        session_id          VARCHAR(100),
+        application_name VARCHAR(128),
+        ip_address          VARCHAR(50),
+  
+        PRIMARY INDEX (entity_id, changed_dts)
+    )
+    PARTITION BY RANGE_N(
+        changed_dts BETWEEN DATE '2020-01-01' AND DATE '2030-12-31'
+        EACH INTERVAL '1' MONTH
+    );
 
-### 9.3 Capturing Change Events
+### 10.3 Capturing Change Events
 
-```sql
--- Example: Capture UPDATE event
-INSERT INTO Observability.ChangeEvent_H (
-    change_event_id, entity_type, entity_id, change_type,
-    changed_by, changed_dts, change_reason,
-    changed_columns, old_values_json, new_values_json
-)
-SELECT 
-    change_event_seq.NEXTVAL,
-    'PARTY',
-    1001,
-    'UPDATE',
-    'data_steward@company.com',
-    CURRENT_TIMESTAMP(6),
-    'Customer name change due to marriage',
-    JSON '["legal_name"]',
-    JSON '{"legal_name": "Jane Doe"}',
-    JSON '{"legal_name": "Jane Smith"}';
-```
+    -- Example: Capture UPDATE event
+    INSERT INTO Observability.ChangeEvent_H (
+        change_event_id, entity_type, entity_id, change_type,
+        changed_by, changed_dts, change_reason,
+        changed_columns, old_values_json, new_values_json
+    )
+    SELECT
+        change_event_seq.NEXTVAL,
+        'PARTY',
+        1001,
+        'UPDATE',
+        'data_steward@company.com',
+        CURRENT_TIMESTAMP(6),
+        'Customer name change due to marriage',
+        JSON '["legal_name"]',
+        JSON '{"legal_name": "Jane Doe"}',
+        JSON '{"legal_name": "Jane Smith"}';
 
-### 9.4 Audit Trail Queries
+### 10.4 Audit Trail Queries
 
-```sql
--- Complete audit history for an entity
-SELECT 
-    changed_dts,
-    changed_by,
-    change_type,
-    change_reason,
-    changed_columns,
-    old_values_json,
-    new_values_json
-FROM Observability.ChangeEvent_H
-WHERE entity_type = 'PARTY'
-  AND entity_id = 1001
-ORDER BY changed_dts;
+    -- Complete audit history for an entity
+    SELECT
+        changed_dts,
+        changed_by,
+        change_type,
+        change_reason,
+        changed_columns,
+        old_values_json,
+        new_values_json
+    FROM Observability.ChangeEvent_H
+    WHERE entity_type = 'PARTY'
+      AND entity_id = 1001
+    ORDER BY changed_dts;
 
--- Who deleted this record and why?
-SELECT changed_by, changed_dts, change_reason
-FROM Observability.ChangeEvent_H
-WHERE entity_type = 'PARTY'
-  AND entity_id = 1001
-  AND change_type = 'DELETE'
-ORDER BY changed_dts DESC
-LIMIT 1;
+    -- Who deleted this record and why?
+    SELECT changed_by, changed_dts, change_reason
+    FROM Observability.ChangeEvent_H
+    WHERE entity_type = 'PARTY'
+      AND entity_id = 1001
+      AND change_type = 'DELETE'
+    ORDER BY changed_dts DESC
+    LIMIT 1;
 
--- All changes by a specific user
-SELECT entity_type, entity_id, change_type, changed_dts
-FROM Observability.ChangeEvent_H
-WHERE changed_by = 'data_steward@company.com'
-  AND changed_dts >= CURRENT_DATE - 30
-ORDER BY changed_dts DESC;
-```
+    -- All changes by a specific user
+    SELECT entity_type, entity_id, change_type, changed_dts
+    FROM Observability.ChangeEvent_H
+    WHERE changed_by = 'data_steward@company.com'
+      AND changed_dts >= CURRENT_DATE - 30
+    ORDER BY changed_dts DESC;
 
-### 9.5 Retention Policy
+### 10.5 Retention Policy
 
 **Advocated retention periods:**
 
 | Audit Data Type | Retention | Rationale |
-|----------------|-----------|-----------|
+| --- | --- | --- |
 | **Recent changes** | 2 years online | Active investigations |
 | **Historical changes** | 7 years archived | Regulatory compliance |
 | **Deletion records** | 10 years archived | GDPR accountability |
@@ -1175,268 +1274,264 @@ ORDER BY changed_dts DESC;
 
 ---
 
-## 10. Platform Implementation Guidance: Teradata
+## 11. Platform Implementation Guidance: Teradata
 
-> **Platform Profile — Teradata**
-> This section is the reference Platform Profile for Teradata implementations of the AI-Native Data Product standard. The structural requirements in the module design standards are platform-agnostic; the guidance below is Teradata-specific. Teams implementing on other platforms should produce an equivalent Platform Profile for their target, covering the same topics: physical key strategy, partitioning, indexing, statistics collection, compression, and query optimisation.
+> **Platform Profile — Teradata** This section is the reference Platform Profile for Teradata implementations of the AI-Native Data Product standard. The structural requirements in the module design standards are platform-agnostic; the guidance below is Teradata-specific. Teams implementing on other platforms should produce an equivalent Platform Profile for their target, covering the same topics: physical key strategy, partitioning, indexing, statistics collection, compression, and query optimisation.
 
-### 10.1 Why Physical Design Matters for AI Workloads
+### 11.1 Why Physical Design Matters for AI Workloads
 
 AI-Native workloads have different access patterns than traditional BI:
+
 - Point-in-time feature computation (temporal queries)
 - High-volume batch processing (ML training)
 - Low-latency single-row lookups (agent queries)
 - Cross-module joins (enriched context)
 
+
 **Advocated approach**: Design physical structures for these specific patterns.
 
-### 10.2 Primary Index Selection
+### 11.2 Primary Index Selection
 
 **Primary Index (PI) is the most critical physical design decision in Teradata.**
 
 #### Advocated PI Selection by Entity Type
 
 | Entity Type | Advocated PI | Rationale |
-|-------------|--------------|-----------|
+| --- | --- | --- |
 | **Core entities** | Surrogate key (UPI) | Even distribution, simple joins |
 | **High-volume entities** | Consider natural key (NUPI) | If frequently queried by business ID |
 | **Reference data** | Code (UPI) | Code lookups most common |
 | **Relationship tables** | Composite FK (NUPI) | Co-locate with parent entity |
 | **Time-series entities** | Composite: entity + time (NUPI) | Partition elimination benefits |
 
+
 #### PI Selection Decision Tree
 
-```
-START: What is primary access pattern?
-├─ Single-row lookup by surrogate key?
-│  └─ Use surrogate key UPI ✅
-├─ Single-row lookup by natural key?
-│  └─ Use natural key UPI ✅
-├─ Range queries on time + entity?
-│  └─ Use composite (entity_id, time_column) NUPI ✅
-├─ Frequent joins to parent entity?
-│  └─ Use parent FK for co-location NUPI ✅
-└─ Mixed patterns?
-   └─ Use surrogate key UPI + secondary indexes ✅
-```
+    START: What is primary access pattern?
+    ├─ Single-row lookup by surrogate key?
+    │  └─ Use surrogate key UPI ✅
+    ├─ Single-row lookup by natural key?
+    │  └─ Use natural key UPI ✅
+    ├─ Range queries on time + entity?
+    │  └─ Use composite (entity_id, time_column) NUPI ✅
+    ├─ Frequent joins to parent entity?
+    │  └─ Use parent FK for co-location NUPI ✅
+    └─ Mixed patterns?
+       └─ Use surrogate key UPI + secondary indexes ✅
 
 #### PI Examples
 
-```sql
--- Pattern 1: Surrogate key UPI (most common)
-CREATE TABLE Party_H (
-    party_id BIGINT NOT NULL,
-    -- ... columns ...
-    PRIMARY INDEX (party_id)
-)
-UNIQUE PRIMARY INDEX (party_id, valid_from_dts, transaction_from_dts);
+    -- Pattern 1: Surrogate key UPI (most common)
+    CREATE TABLE Party_H (
+        party_id BIGINT NOT NULL,
+        -- ... columns ...
+        PRIMARY INDEX (party_id)
+    )
+    UNIQUE PRIMARY INDEX (party_id, valid_from_dts, transaction_from_dts);
 
--- Pattern 2: Natural key UPI (frequent business ID queries)
-CREATE TABLE Product_H (
-    product_id BIGINT NOT NULL,
-    product_key VARCHAR(50) NOT NULL,
-    -- ... columns ...
-    PRIMARY INDEX (product_key)  -- If most queries filter on product_key
-)
-UNIQUE PRIMARY INDEX (product_id, valid_from_dts, transaction_from_dts);
+    -- Pattern 2: Natural key UPI (frequent business ID queries)
+    CREATE TABLE Product_H (
+        product_id BIGINT NOT NULL,
+        product_key VARCHAR(50) NOT NULL,
+        -- ... columns ...
+        PRIMARY INDEX (product_key)  -- If most queries filter on product_key
+    )
+    UNIQUE PRIMARY INDEX (product_id, valid_from_dts, transaction_from_dts);
 
--- Pattern 3: Composite NUPI (relationship table, co-located)
-CREATE TABLE PartyProduct_H (
-    party_product_id BIGINT NOT NULL,
-    party_id BIGINT NOT NULL,
-    product_id BIGINT NOT NULL,
-    -- ... columns ...
-    PRIMARY INDEX (party_id, product_id)  -- Co-locate with Party
-)
-UNIQUE PRIMARY INDEX (party_product_id, valid_from_dts, transaction_from_dts);
+    -- Pattern 3: Composite NUPI (relationship table, co-located)
+    CREATE TABLE PartyProduct_H (
+        party_product_id BIGINT NOT NULL,
+        party_id BIGINT NOT NULL,
+        product_id BIGINT NOT NULL,
+        -- ... columns ...
+        PRIMARY INDEX (party_id, product_id)  -- Co-locate with Party
+    )
+    UNIQUE PRIMARY INDEX (party_product_id, valid_from_dts, transaction_from_dts);
 
--- Pattern 4: Time-based composite (time-series data)
-CREATE TABLE Transaction_H (
-    transaction_id BIGINT NOT NULL,
-    party_id BIGINT NOT NULL,
-    transaction_dts TIMESTAMP(6) WITH TIME ZONE NOT NULL,
-    -- ... columns ...
-    PRIMARY INDEX (party_id, transaction_dts)  -- Time-series queries
-)
-UNIQUE PRIMARY INDEX (transaction_id, valid_from_dts, transaction_from_dts)
-PARTITION BY RANGE_N(
-    transaction_dts BETWEEN DATE '2020-01-01' AND DATE '2030-12-31' 
-    EACH INTERVAL '1' MONTH
-);
-```
+    -- Pattern 4: Time-based composite (time-series data)
+    CREATE TABLE Transaction_H (
+        transaction_id BIGINT NOT NULL,
+        party_id BIGINT NOT NULL,
+        transaction_dts TIMESTAMP(6) WITH TIME ZONE NOT NULL,
+        -- ... columns ...
+        PRIMARY INDEX (party_id, transaction_dts)  -- Time-series queries
+    )
+    UNIQUE PRIMARY INDEX (transaction_id, valid_from_dts, transaction_from_dts)
+    PARTITION BY RANGE_N(
+        transaction_dts BETWEEN DATE '2020-01-01' AND DATE '2030-12-31'
+        EACH INTERVAL '1' MONTH
+    );
 
-### 10.3 Partitioning Strategy
+### 11.3 Partitioning Strategy
 
 **Advocate partitioning for:**
+
 - Tables > 100M rows
 - Time-series access patterns
 - Need for partition elimination
 
+
 #### Advocated Partitioning Approaches
 
 | Partitioning Dimension | When to Use | Example |
-|------------------------|-------------|---------|
+| --- | --- | --- |
 | **Transaction time** | Most common - queries filter on load/update date | `transaction_from_dts` |
 | **Valid time** | Business queries filter on effective date | `valid_from_dts` |
 | **Date attribute** | Event data with natural dates | `transaction_date`, `order_date` |
 | **Multi-level** | Combine time + status/type | Time + is_deleted |
 
+
 #### Partitioning Examples
 
-```sql
--- Pattern 1: Monthly partitioning (most common)
-PARTITION BY RANGE_N(
-    transaction_from_dts BETWEEN DATE '2020-01-01' 
-                           AND DATE '2030-12-31' 
-                           EACH INTERVAL '1' MONTH
-);
+    -- Pattern 1: Monthly partitioning (most common)
+    PARTITION BY RANGE_N(
+        transaction_from_dts BETWEEN DATE '2020-01-01'
+                               AND DATE '2030-12-31'
+                               EACH INTERVAL '1' MONTH
+    );
 
--- Pattern 2: Quarterly partitioning (moderate volume)
-PARTITION BY RANGE_N(
-    transaction_from_dts BETWEEN DATE '2020-01-01' 
-                           AND DATE '2030-12-31' 
-                           EACH INTERVAL '3' MONTH
-);
+    -- Pattern 2: Quarterly partitioning (moderate volume)
+    PARTITION BY RANGE_N(
+        transaction_from_dts BETWEEN DATE '2020-01-01'
+                               AND DATE '2030-12-31'
+                               EACH INTERVAL '3' MONTH
+    );
 
--- Pattern 3: Daily partitioning (very high volume)
-PARTITION BY RANGE_N(
-    transaction_dts BETWEEN DATE '2024-01-01' 
-                      AND DATE '2025-12-31' 
-                      EACH INTERVAL '1' DAY
-);
+    -- Pattern 3: Daily partitioning (very high volume)
+    PARTITION BY RANGE_N(
+        transaction_dts BETWEEN DATE '2024-01-01'
+                          AND DATE '2025-12-31'
+                          EACH INTERVAL '1' DAY
+    );
 
--- Pattern 4: Multi-level (time + status)
-PARTITION BY (
-    RANGE_N(
-        valid_from_dts BETWEEN DATE '2020-01-01' 
-                        AND DATE '2030-12-31' 
-                        EACH INTERVAL '1' YEAR
-    ),
-    CASE_N(
-        is_deleted = 0,   -- Partition 1: Active
-        is_deleted = 1,   -- Partition 2: Deleted
-        UNKNOWN           -- Partition 3: NULL
-    )
-);
-```
+    -- Pattern 4: Multi-level (time + status)
+    PARTITION BY (
+        RANGE_N(
+            valid_from_dts BETWEEN DATE '2020-01-01'
+                            AND DATE '2030-12-31'
+                            EACH INTERVAL '1' YEAR
+        ),
+        CASE_N(
+            is_deleted = 0,   -- Partition 1: Active
+            is_deleted = 1,   -- Partition 2: Deleted
+            UNKNOWN           -- Partition 3: NULL
+        )
+    );
 
 #### Partitioning Decision Tree
 
-```
-START: Table size?
-├─ < 100M rows → No partitioning needed ⚠️
-└─ > 100M rows → What's primary query pattern?
-   ├─ Time range queries common?
-   │  └─ Partition by time column ✅
-   ├─ Status/type filtering common?
-   │  └─ Consider multi-level partitioning ✅
-   └─ Full table scans anyway?
-      └─ Partitioning won't help ⚠️
-```
+    START: Table size?
+    ├─ < 100M rows → No partitioning needed ⚠️
+    └─ > 100M rows → What's primary query pattern?
+       ├─ Time range queries common?
+       │  └─ Partition by time column ✅
+       ├─ Status/type filtering common?
+       │  └─ Consider multi-level partitioning ✅
+       └─ Full table scans anyway?
+          └─ Partitioning won't help ⚠️
 
-### 10.4 Secondary Index Strategy
+### 11.4 Secondary Index Strategy
 
 **Advocate selective use of secondary indexes.**
 
 #### When to Create Secondary Indexes
 
 | Create SI When: | Avoid SI When: |
-|-----------------|----------------|
+| --- | --- |
 | ✅ Critical query doesn't use PI | ❌ Query is rare/ad-hoc |
 | ✅ Query performance unacceptable | ❌ PI already covers query |
 | ✅ Insert volume is moderate | ❌ High insert/update volume |
 | ✅ Query is frequent | ❌ Query is already fast |
 
+
 #### Advocated Secondary Index Patterns
 
-```sql
--- Pattern 1: Natural key index (when PI is surrogate key)
-CREATE UNIQUE INDEX idx_party_natural_key
-ON Party_H (party_key)
-WHERE is_current = 1 AND is_deleted = 0;
+    -- Pattern 1: Natural key index (when PI is surrogate key)
+    CREATE UNIQUE INDEX idx_party_natural_key
+    ON Party_H (party_key)
+    WHERE is_current = 1 AND is_deleted = 0;
 
--- Pattern 2: Foreign key index (for join optimization)
-CREATE INDEX idx_partyproduct_product
-ON PartyProduct_H (product_id)
-WHERE is_current = 1 AND is_deleted = 0;
+    -- Pattern 2: Foreign key index (for join optimization)
+    CREATE INDEX idx_partyproduct_product
+    ON PartyProduct_H (product_id)
+    WHERE is_current = 1 AND is_deleted = 0;
 
--- Pattern 3: Composite index (multi-column filters)
-CREATE INDEX idx_product_category_type
-ON Product_H (product_category, product_type_code)
-WHERE is_current = 1 AND is_deleted = 0;
+    -- Pattern 3: Composite index (multi-column filters)
+    CREATE INDEX idx_product_category_type
+    ON Product_H (product_category, product_type_code)
+    WHERE is_current = 1 AND is_deleted = 0;
 
--- Pattern 4: Covering index (include frequently selected columns)
-CREATE INDEX idx_party_lookup (party_key, legal_name, status_code)
-ON Party_H (party_key)
-WHERE is_current = 1 AND is_deleted = 0;
-```
+    -- Pattern 4: Covering index (include frequently selected columns)
+    CREATE INDEX idx_party_lookup (party_key, legal_name, status_code)
+    ON Party_H (party_key)
+    WHERE is_current = 1 AND is_deleted = 0;
 
-### 10.5 Join Index Strategy
+### 11.5 Join Index Strategy
 
 **Advocate join indexes for:**
+
 - Expensive joins used frequently
 - Pre-computed aggregations
 - Materialized views
 
+
 #### Join Index Patterns
 
-```sql
--- Pattern 1: Current version materialized view
-CREATE JOIN INDEX jidx_party_current AS
-SELECT 
-    party_id,
-    party_key,
-    legal_name,
-    party_type_code,
-    status_code
-FROM Party_H
-WHERE is_current = 1
-  AND is_deleted = 0
-  AND transaction_to_dts = TIMESTAMP '9999-12-31 23:59:59.999999+00:00'
-PRIMARY INDEX (party_id);
+    -- Pattern 1: Current version materialized view
+    CREATE JOIN INDEX jidx_party_current AS
+    SELECT
+        party_id,
+        party_key,
+        legal_name,
+        party_type_code,
+        status_code
+    FROM Party_H
+    WHERE is_current = 1
+      AND is_deleted = 0
+      AND transaction_to_dts = TIMESTAMP '9999-12-31 23:59:59.999999+00:00'
+    PRIMARY INDEX (party_id);
 
--- Pattern 2: Denormalized join (frequent join pattern)
-CREATE JOIN INDEX jidx_party_product_denorm AS
-SELECT 
-    p.party_id,
-    p.party_key,
-    p.legal_name,
-    pp.product_id,
-    pr.product_key,
-    pr.product_name
-FROM Party_H p
-INNER JOIN PartyProduct_H pp 
-    ON p.party_id = pp.party_id
-INNER JOIN Product_H pr 
-    ON pp.product_id = pr.product_id
-WHERE p.is_current = 1 AND p.is_deleted = 0
-  AND pp.is_current = 1 AND pp.is_deleted = 0
-  AND pr.is_current = 1 AND pr.is_deleted = 0
-PRIMARY INDEX (party_id);
+    -- Pattern 2: Denormalized join (frequent join pattern)
+    CREATE JOIN INDEX jidx_party_product_denorm AS
+    SELECT
+        p.party_id,
+        p.party_key,
+        p.legal_name,
+        pp.product_id,
+        pr.product_key,
+        pr.product_name
+    FROM Party_H p
+    INNER JOIN PartyProduct_H pp
+        ON p.party_id = pp.party_id
+    INNER JOIN Product_H pr
+        ON pp.product_id = pr.product_id
+    WHERE p.is_current = 1 AND p.is_deleted = 0
+      AND pp.is_current = 1 AND pp.is_deleted = 0
+      AND pr.is_current = 1 AND pr.is_deleted = 0
+    PRIMARY INDEX (party_id);
 
--- Pattern 3: Pre-computed aggregation
-CREATE JOIN INDEX jidx_party_metrics AS
-SELECT 
-    party_id,
-    COUNT(*) AS product_cnt,
-    SUM(balance_amt) AS total_balance_amt,
-    MAX(last_transaction_dts) AS last_activity_dts
-FROM Party_H p
-INNER JOIN PartyProduct_H pp ON p.party_id = pp.party_id
-WHERE p.is_current = 1 AND p.is_deleted = 0
-  AND pp.is_current = 1 AND pp.is_deleted = 0
-GROUP BY party_id
-PRIMARY INDEX (party_id);
-```
+    -- Pattern 3: Pre-computed aggregation
+    CREATE JOIN INDEX jidx_party_metrics AS
+    SELECT
+        party_id,
+        COUNT(*) AS product_cnt,
+        SUM(balance_amt) AS total_balance_amt,
+        MAX(last_transaction_dts) AS last_activity_dts
+    FROM Party_H p
+    INNER JOIN PartyProduct_H pp ON p.party_id = pp.party_id
+    WHERE p.is_current = 1 AND p.is_deleted = 0
+      AND pp.is_current = 1 AND pp.is_deleted = 0
+    GROUP BY party_id
+    PRIMARY INDEX (party_id);
 
-### 10.6 Compression Strategy
+### 11.6 Compression Strategy
 
 **Advocate compression for large text columns.**
 
 #### Compression Candidates
 
 | Column Type | Compress? | Method |
-|-------------|-----------|--------|
+| --- | --- | --- |
 | **Large text (>500 chars)** | ✅ Yes | AUTO COMPRESS |
 | **JSON columns** | ✅ Yes | AUTO COMPRESS or ZLIB |
 | **Sparse columns** | ✅ Yes | AUTO COMPRESS |
@@ -1444,67 +1539,65 @@ PRIMARY INDEX (party_id);
 | **Numeric columns** | ❌ No | Minimal benefit |
 | **Frequently updated** | ⚠️ Caution | Recompression cost |
 
+
 #### Compression Examples
 
-```sql
--- Pattern 1: AUTO COMPRESS (recommended)
-CREATE TABLE Party_H (
-    party_id BIGINT NOT NULL,
-    -- ... other columns ...
-    notes_txt VARCHAR(5000),
-    address_text VARCHAR(500)
-)
-WITH COLUMN_PARTITION = (
-    AUTO COMPRESS (notes_txt, address_text)
-);
+    -- Pattern 1: AUTO COMPRESS (recommended)
+    CREATE TABLE Party_H (
+        party_id BIGINT NOT NULL,
+        -- ... other columns ...
+        notes_txt VARCHAR(5000),
+        address_text VARCHAR(500)
+    )
+    WITH COLUMN_PARTITION = (
+        AUTO COMPRESS (notes_txt, address_text)
+    );
 
--- Pattern 2: Specific algorithm for very large text
-CREATE TABLE Document_H (
-    document_id BIGINT NOT NULL,
-    document_content CLOB
-)
-WITH COLUMN_PARTITION = (
-    COLUMN (document_content) COMPRESS USING ZLIBHIGH
-);
-```
+    -- Pattern 2: Specific algorithm for very large text
+    CREATE TABLE Document_H (
+        document_id BIGINT NOT NULL,
+        document_content CLOB
+    )
+    WITH COLUMN_PARTITION = (
+        COLUMN (document_content) COMPRESS USING ZLIBHIGH
+    );
 
-### 10.7 Statistics Collection
+### 11.7 Statistics Collection
 
 **Advocate automated statistics collection.**
 
 #### Statistics Strategy
 
-```sql
--- Collect stats on critical columns
-COLLECT STATISTICS 
-COLUMN (party_id),
-COLUMN (party_key),
-COLUMN (party_type_code),
-COLUMN (is_current),
-COLUMN (is_deleted),
-COLUMN (valid_from_dts),
-COLUMN (transaction_from_dts)
-ON Party_H;
+    -- Collect stats on critical columns
+    COLLECT STATISTICS
+    COLUMN (party_id),
+    COLUMN (party_key),
+    COLUMN (party_type_code),
+    COLUMN (is_current),
+    COLUMN (is_deleted),
+    COLUMN (valid_from_dts),
+    COLUMN (transaction_from_dts)
+    ON Party_H;
 
--- Collect stats on composite filters
-COLLECT STATISTICS 
-COLUMN (party_type_code, is_current, is_deleted)
-ON Party_H;
+    -- Collect stats on composite filters
+    COLLECT STATISTICS
+    COLUMN (party_type_code, is_current, is_deleted)
+    ON Party_H;
 
--- For large tables, use sampling
-COLLECT STATISTICS ON Party_H USING SAMPLE 10 PERCENT;
-```
+    -- For large tables, use sampling
+    COLLECT STATISTICS ON Party_H USING SAMPLE 10 PERCENT;
 
 #### Advocated Collection Schedule
 
 | Table Size | Frequency | Method |
-|------------|-----------|--------|
+| --- | --- | --- |
 | **< 1M rows** | After major loads | Full scan |
 | **1M - 100M rows** | Daily | 10% sample |
 | **> 100M rows** | Weekly | 5% sample |
 | **Reference tables** | After changes only | Full scan |
 
-### 10.8 Physical Design Checklist
+
+### 11.8 Physical Design Checklist
 
 **Before implementation:**
 
@@ -1520,75 +1613,68 @@ COLLECT STATISTICS ON Party_H USING SAMPLE 10 PERCENT;
 
 ---
 
-## 11. Implementation Decision Trees
+## 12. Implementation Decision Trees
 
-### 10.1 Temporal Pattern Decision
+### 12.1 Temporal Pattern Decision
 
-```
-START: Do you need point-in-time correctness for ML features?
-├─ YES → Are late-arriving facts common?
-│  ├─ YES → Use BI-TEMPORAL ✅ (Advocated)
-│  └─ NO → Are corrections needed?
-│     ├─ YES → Use BI-TEMPORAL ✅
-│     └─ NO → Type 2 SCD acceptable ⚠️
-└─ NO → Is complete audit trail required?
-   ├─ YES → Use BI-TEMPORAL ✅
-   └─ NO → Type 2 SCD acceptable ⚠️
-```
+    START: Do you need point-in-time correctness for ML features?
+    ├─ YES → Are late-arriving facts common?
+    │  ├─ YES → Use BI-TEMPORAL ✅ (Advocated)
+    │  └─ NO → Are corrections needed?
+    │     ├─ YES → Use BI-TEMPORAL ✅
+    │     └─ NO → Type 2 SCD acceptable ⚠️
+    └─ NO → Is complete audit trail required?
+       ├─ YES → Use BI-TEMPORAL ✅
+       └─ NO → Type 2 SCD acceptable ⚠️
 
-### 10.2 Column Strategy Decision
+### 12.2 Column Strategy Decision
 
-```
-START: What is table volume?
-├─ < 10M rows → Core + Extended OK ⚠️
-├─ 10M - 100M rows → Core + FK Refs ✅ (Advocated)
-└─ > 100M rows → Core Only + Views ✅ (Advocated)
-    │
-    ├─ Need fast audit access?
-    │  ├─ YES → Add change_event_id FK
-    │  └─ NO → Join by entity_id (no FK)
-    │
-    ├─ Need fast lineage access?
-    │  ├─ YES → Add lineage_id FK
-    │  └─ NO → Join by entity_id (no FK)
-    │
-    └─ Need fast quality access?
-       ├─ YES → Add quality_id FK
-       └─ NO → Join by entity_id (no FK)
-```
+    START: What is table volume?
+    ├─ < 10M rows → Core + Extended OK ⚠️
+    ├─ 10M - 100M rows → Core + FK Refs ✅ (Advocated)
+    └─ > 100M rows → Core Only + Views ✅ (Advocated)
+        │
+        ├─ Need fast audit access?
+        │  ├─ YES → Add change_event_id FK
+        │  └─ NO → Join by entity_id (no FK)
+        │
+        ├─ Need fast lineage access?
+        │  ├─ YES → Add lineage_id FK
+        │  └─ NO → Join by entity_id (no FK)
+        │
+        └─ Need fast quality access?
+           ├─ YES → Add quality_id FK
+           └─ NO → Join by entity_id (no FK)
 
-### 10.3 Delete Strategy Decision
+### 12.3 Delete Strategy Decision
 
-```
-START: Is regulatory audit trail required?
-├─ YES → SOFT DELETE ✅ (Advocated)
-└─ NO → Do ML features depend on deletion status?
-   ├─ YES → SOFT DELETE ✅
-   └─ NO → Need analytics on deletion patterns?
-      ├─ YES → SOFT DELETE ✅
-      └─ NO → Is storage extremely constrained?
-         ├─ YES → Hard delete acceptable ⚠️
-         └─ NO → SOFT DELETE ✅ (safest default)
-```
+    START: Is regulatory audit trail required?
+    ├─ YES → SOFT DELETE ✅ (Advocated)
+    └─ NO → Do ML features depend on deletion status?
+       ├─ YES → SOFT DELETE ✅
+       └─ NO → Need analytics on deletion patterns?
+          ├─ YES → SOFT DELETE ✅
+          └─ NO → Is storage extremely constrained?
+             ├─ YES → Hard delete acceptable ⚠️
+             └─ NO → SOFT DELETE ✅ (safest default)
 
-### 10.4 Quality Storage Decision
+### 12.4 Quality Storage Decision
 
-```
-START: What is table volume?
-├─ < 10M rows → Either approach OK
-│  ├─ Simple implementation priority? → Store in Domain ⚠️
-│  └─ Quality history needed? → Store in Observability ✅
-└─ > 10M rows → Store in Observability ✅ (Advocated)
-    │
-    └─ Create views for agent access? → YES ✅ (Always)
-```
+    START: What is table volume?
+    ├─ < 10M rows → Either approach OK
+    │  ├─ Simple implementation priority? → Store in Domain ⚠️
+    │  └─ Quality history needed? → Store in Observability ✅
+    └─ > 10M rows → Store in Observability ✅ (Advocated)
+        │
+        └─ Create views for agent access? → YES ✅ (Always)
 
 ---
 
 ## Document Change Log
 
 | Version | Date | Changes | Author |
-|---------|------|---------|--------|
+| --- | --- | --- | --- |
+| 1.6 | 2026-05-08 | Added Section 6 (Access Layer). Defers placement, naming, separation, and access to the Object Placement Standard (interface specification + platform implementations). Establishes the principle of reading through views without prescribing where tables and views are placed. Lists builder/agent behaviour: locate a conforming Object Placement Standard before generating any object; halt and ask if absent. Sections 6–11 renumbered to 7–12. Subsection numbers within the renumbered Implementation Decision Trees corrected from 11.1–11.4 to 12.1–12.4. | Paul Dancer, Worldwide Field Tech, Teradata |
 | 1.5 | 2026-04-15 | Established platform neutrality. Renamed Section 10 from "Physical Design for Teradata" to "Platform Implementation Guidance: Teradata" and added a Platform Profile preamble making explicit that this section is Teradata-specific and that other platforms should produce equivalent profiles. Section 10 content unchanged. | Nathan Green, Worldwide Data Architecture Team, Teradata |
 | 1.4 | 2026-04-10 | Section 4 (Surrogate Key Strategy) rewritten to address surrogate key instability in SCD Type 2 tables (issue #7). Added Section 4.2 explaining why IDENTITY on _H tables fails; Section 4.3 documenting the recommended Keymap pattern (with flexibility note that organisations should use their own standard if one exists); Section 4.4 (Reference and Lookup Table Exemption) clarifying that reference/lookup tables and detail entities not FK-referenced may use IDENTITY directly; Section 4.5 providing a decision tree with three allocation options; Section 4.6 (natural keys, renamed from old 4.4). Removed old Sections 4.2-4.3 which incorrectly advocated IDENTITY on _H tables. | Nathan Green, Worldwide Data Architecture Team, Teradata |
 | 1.3 | 2026-03-20 | Completed swap of id and key to be consistent throughout design standards | Nathan Green, Worldwide Data Architecture Team, Teradata |

--- a/design-standards/Advocated_Data_Management_Standards.md
+++ b/design-standards/Advocated_Data_Management_Standards.md
@@ -1,4 +1,5 @@
 # Advocated Data Management Standards
+
 ## AI-Native Data Product Architecture - Teradata Recommendations
 
 ---
@@ -6,10 +7,10 @@
 ## Document Control
 
 | Attribute | Value |
-|-----------|-------|
-| **Version** | 1.5 |
+| --- | --- |
+| **Version** | 1.6 |
 | **Status** | GUIDANCE |
-| **Last Updated** | 2026-04-10 |
+| **Last Updated** | 2026-05-08 |
 | **Owner** | Data Architecture |
 | **Scope** | Cross-Module Data Management Guidance |
 | **Type** | Recommended Practices |
@@ -23,11 +24,13 @@
 3. [Column Optimization Strategy](#3-column-optimization-strategy)
 4. [Surrogate Key Strategy](#4-surrogate-key-strategy)
 5. [Soft Delete Pattern](#5-soft-delete-pattern)
-6. [Observability Offload Pattern](#6-observability-offload-pattern)
-7. [Timezone Handling](#7-timezone-handling)
-8. [Data Quality Management](#8-data-quality-management)
-9. [Audit Trail Strategy](#9-audit-trail-strategy)
-10. [Implementation Decision Trees](#10-implementation-decision-trees)
+6. [Access Layer](#6-access-layer)
+7. [Observability Offload Pattern](#7-observability-offload-pattern)
+8. [Timezone Handling](#8-timezone-handling)
+9. [Data Quality Management](#9-data-quality-management)
+10. [Audit Trail Strategy](#10-audit-trail-strategy)
+11. [Platform Implementation Guidance: Teradata](#11-platform-implementation-guidance-teradata)
+12. [Implementation Decision Trees](#12-implementation-decision-trees)
 
 ---
 
@@ -42,22 +45,24 @@ This document provides **Teradata's recommended practices** for data management 
 ### 1.2 How to Use This Guidance
 
 | Your Situation | How to Apply |
-|----------------|--------------|
+| --- | --- |
 | **Starting fresh** | Adopt these practices as defaults |
 | **Existing patterns** | Evaluate selective adoption |
 | **Specific constraints** | Adapt patterns to your context |
 | **Different philosophy** | Document your alternative approach |
 
+
 ### 1.3 Advocacy vs Mandate
 
 | This Document ADVOCATES | Design Standard MANDATES |
-|------------------------|--------------------------|
+| --- | --- |
 | Bi-temporal tracking | Module structure |
 | Surrogate keys | Naming conventions |
 | Soft deletes | Cross-module integration patterns |
 | Observability offload | Agent discoverability |
 | TIMESTAMP WITH TIME ZONE | View standards |
 | Column optimization | - |
+
 
 **Remember**: You can build AI-Native data products using different temporal patterns, different key strategies, or different column approaches—as long as you follow the structural patterns in the Design Standard.
 
@@ -67,13 +72,12 @@ This document provides **Teradata's recommended practices** for data management 
 
 ### 2.1 Why We Advocate Bi-Temporal
 
-**Traditional Approach**: Type 2 SCD (single time dimension)
-**Advocated Approach**: Bi-temporal (two independent time dimensions)
+**Traditional Approach**: Type 2 SCD (single time dimension) **Advocated Approach**: Bi-temporal (two independent time dimensions)
 
 #### Key Benefits for AI-Native Data Products
 
 | Requirement | Type 2 SCD | Bi-Temporal |
-|-------------|-----------|-------------|
+| --- | --- | --- |
 | **Point-in-time correctness** | ⚠️ Approximate | ✅ Exact |
 | **Late-arriving facts** | ❌ Corrupts history | ✅ Preserves history |
 | **Corrections tracking** | ❌ Lost | ✅ Traceable |
@@ -81,217 +85,203 @@ This document provides **Teradata's recommended practices** for data management 
 | **Audit trail** | ⚠️ Partial | ✅ Complete |
 | **Explainability** | ⚠️ Limited | ✅ Full reconstruction |
 
+
 ### 2.2 The Two Time Dimensions
 
-```
-Example: Customer changes name from "Jane Doe" to "Jane Smith"
+    Example: Customer changes name from "Jane Doe" to "Jane Smith"
 
-Real World Event:
-- Marriage happens on 2024-06-15 (Valid Time)
+    Real World Event:
+    - Marriage happens on 2024-06-15 (Valid Time)
 
-Database Recording:
-- We learn about it on 2024-07-01 (Transaction Time)
+    Database Recording:
+    - We learn about it on 2024-07-01 (Transaction Time)
 
-Bi-Temporal Record:
-- valid_from_dts = 2024-06-15 (when it became true in reality)
-- transaction_from_dts = 2024-07-01 (when we recorded it)
-```
+    Bi-Temporal Record:
+    - valid_from_dts = 2024-06-15 (when it became true in reality)
+    - transaction_from_dts = 2024-07-01 (when we recorded it)
 
-**Valid Time**: When the fact was TRUE in the real world
-**Transaction Time**: When the fact was RECORDED in the database
+**Valid Time**: When the fact was TRUE in the real world **Transaction Time**: When the fact was RECORDED in the database
 
 ### 2.3 Advocated Bi-Temporal Column Set
 
-```sql
--- ADVOCATED: Bi-temporal columns
-valid_from_dts      TIMESTAMP(6) WITH TIME ZONE NOT NULL
-    COMMENT 'When this version became true in real world',
+    -- ADVOCATED: Bi-temporal columns
+    valid_from_dts      TIMESTAMP(6) WITH TIME ZONE NOT NULL
+        COMMENT 'When this version became true in real world',
 
-valid_to_dts        TIMESTAMP(6) WITH TIME ZONE NOT NULL 
-    DEFAULT TIMESTAMP '9999-12-31 23:59:59.999999+00:00'
-    COMMENT 'When this version stopped being true in real world',
+    valid_to_dts        TIMESTAMP(6) WITH TIME ZONE NOT NULL
+        DEFAULT TIMESTAMP '9999-12-31 23:59:59.999999+00:00'
+        COMMENT 'When this version stopped being true in real world',
 
-transaction_from_dts TIMESTAMP(6) WITH TIME ZONE NOT NULL 
-    DEFAULT CURRENT_TIMESTAMP(6)
-    COMMENT 'When this version was inserted into database',
+    transaction_from_dts TIMESTAMP(6) WITH TIME ZONE NOT NULL
+        DEFAULT CURRENT_TIMESTAMP(6)
+        COMMENT 'When this version was inserted into database',
 
-transaction_to_dts   TIMESTAMP(6) WITH TIME ZONE NOT NULL 
-    DEFAULT TIMESTAMP '9999-12-31 23:59:59.999999+00:00'
-    COMMENT 'When this version was superseded in database',
+    transaction_to_dts   TIMESTAMP(6) WITH TIME ZONE NOT NULL
+        DEFAULT TIMESTAMP '9999-12-31 23:59:59.999999+00:00'
+        COMMENT 'When this version was superseded in database',
 
-is_current  BYTEINT NOT NULL DEFAULT 1
-    COMMENT '1 = Current version, 0 = Historical version',
-```
+    is_current  BYTEINT NOT NULL DEFAULT 1
+        COMMENT '1 = Current version, 0 = Historical version',
 
 **IMPORTANT: PRIMARY INDEX for Temporal Tables**
 
 Temporal tables (bi-temporal, Type 2 SCD, versioned) should use **PRIMARY INDEX** (NUPI), not UNIQUE PRIMARY INDEX, because:
+
 - Multiple versions exist for the same entity_id
 - Historical records create natural duplicates
 - UNIQUE PRIMARY INDEX would prevent version updates
 
-```sql
--- CORRECT for temporal tables
-CREATE TABLE Party_H (
-    party_id BIGINT NOT NULL,
-    -- ... bi-temporal columns ...
-)
-PRIMARY INDEX (party_id);  -- NUPI allows multiple versions
 
--- INCORRECT for temporal tables
-CREATE TABLE Party_H (
-    party_id BIGINT NOT NULL,
-    -- ... bi-temporal columns ...
-)
-UNIQUE PRIMARY INDEX (party_id);  -- Would fail on version 2
-```
+    -- CORRECT for temporal tables
+    CREATE TABLE Party_H (
+        party_id BIGINT NOT NULL,
+        -- ... bi-temporal columns ...
+    )
+    PRIMARY INDEX (party_id);  -- NUPI allows multiple versions
+
+    -- INCORRECT for temporal tables
+    CREATE TABLE Party_H (
+        party_id BIGINT NOT NULL,
+        -- ... bi-temporal columns ...
+    )
+    UNIQUE PRIMARY INDEX (party_id);  -- Would fail on version 2
 
 **Use UNIQUE PRIMARY INDEX only for:**
+
 - Non-temporal tables (no versioning)
 - Reference data with unique codes
 - Tables where each key appears exactly once
+
 
 ### 2.4 Bi-Temporal Operations
 
 #### Insert New Entity (Version 1)
 
-```sql
-INSERT INTO Party_H (
-    party_id, party_key, legal_name,
-    valid_from_dts, valid_to_dts,
-    transaction_from_dts, transaction_to_dts,
-    is_current, is_deleted
-) VALUES (
-    1001, 'CUST-12345', 'Jane Doe',
-    TIMESTAMP '2024-01-01 00:00:00+00:00',
-    TIMESTAMP '9999-12-31 23:59:59.999999+00:00',
-    CURRENT_TIMESTAMP(6),
-    TIMESTAMP '9999-12-31 23:59:59.999999+00:00',
-    1, 0
-);
-```
+    INSERT INTO Party_H (
+        party_id, party_key, legal_name,
+        valid_from_dts, valid_to_dts,
+        transaction_from_dts, transaction_to_dts,
+        is_current, is_deleted
+    ) VALUES (
+        1001, 'CUST-12345', 'Jane Doe',
+        TIMESTAMP '2024-01-01 00:00:00+00:00',
+        TIMESTAMP '9999-12-31 23:59:59.999999+00:00',
+        CURRENT_TIMESTAMP(6),
+        TIMESTAMP '9999-12-31 23:59:59.999999+00:00',
+        1, 0
+    );
 
 #### Update Entity (Create Version 2)
 
-```sql
--- Step 1: Close out current version
-UPDATE Party_H
-SET valid_to_dts = TIMESTAMP '2024-06-15 00:00:00+00:00',
-    transaction_to_dts = CURRENT_TIMESTAMP(6),
-    is_current = 0
-WHERE party_id = 1001 AND is_current = 1;
+    -- Step 1: Close out current version
+    UPDATE Party_H
+    SET valid_to_dts = TIMESTAMP '2024-06-15 00:00:00+00:00',
+        transaction_to_dts = CURRENT_TIMESTAMP(6),
+        is_current = 0
+    WHERE party_id = 1001 AND is_current = 1;
 
--- Step 2: Insert new version
-INSERT INTO Party_H (
-    party_id, party_key, legal_name,
-    valid_from_dts, valid_to_dts,
-    transaction_from_dts, transaction_to_dts,
-    is_current, is_deleted
-) VALUES (
-    1001, 'CUST-12345', 'Jane Smith',  -- NAME CHANGED
-    TIMESTAMP '2024-06-15 00:00:00+00:00',  -- When change occurred
-    TIMESTAMP '9999-12-31 23:59:59.999999+00:00',
-    CURRENT_TIMESTAMP(6),  -- When we recorded it
-    TIMESTAMP '9999-12-31 23:59:59.999999+00:00',
-    1, 0
-);
-```
+    -- Step 2: Insert new version
+    INSERT INTO Party_H (
+        party_id, party_key, legal_name,
+        valid_from_dts, valid_to_dts,
+        transaction_from_dts, transaction_to_dts,
+        is_current, is_deleted
+    ) VALUES (
+        1001, 'CUST-12345', 'Jane Smith',  -- NAME CHANGED
+        TIMESTAMP '2024-06-15 00:00:00+00:00',  -- When change occurred
+        TIMESTAMP '9999-12-31 23:59:59.999999+00:00',
+        CURRENT_TIMESTAMP(6),  -- When we recorded it
+        TIMESTAMP '9999-12-31 23:59:59.999999+00:00',
+        1, 0
+    );
 
 #### Correct Historical Data (Late-Arriving Fact)
 
-```sql
--- Scenario: Discovered marriage actually happened on 2024-06-10, not 2024-06-15
--- We need to correct valid_from_dts but preserve transaction history
+    -- Scenario: Discovered marriage actually happened on 2024-06-10, not 2024-06-15
+    -- We need to correct valid_from_dts but preserve transaction history
 
--- Step 1: Close incorrect version in transaction time
-UPDATE Party_H
-SET transaction_to_dts = CURRENT_TIMESTAMP(6),
-    is_current = 0
-WHERE party_id = 1001
-  AND valid_from_dts = TIMESTAMP '2024-06-15 00:00:00+00:00'
-  AND is_current = 1;
+    -- Step 1: Close incorrect version in transaction time
+    UPDATE Party_H
+    SET transaction_to_dts = CURRENT_TIMESTAMP(6),
+        is_current = 0
+    WHERE party_id = 1001
+      AND valid_from_dts = TIMESTAMP '2024-06-15 00:00:00+00:00'
+      AND is_current = 1;
 
--- Step 2: Insert corrected version with new transaction time
-INSERT INTO Party_H (
-    party_id, party_key, legal_name,
-    valid_from_dts, valid_to_dts,
-    transaction_from_dts, transaction_to_dts,
-    is_current, is_deleted
-) VALUES (
-    1001, 'CUST-12345', 'Jane Smith',
-    TIMESTAMP '2024-06-10 00:00:00+00:00',  -- CORRECTED valid time
-    TIMESTAMP '9999-12-31 23:59:59.999999+00:00',
-    CURRENT_TIMESTAMP(6),  -- NEW transaction time
-    TIMESTAMP '9999-12-31 23:59:59.999999+00:00',
-    1, 0
-);
+    -- Step 2: Insert corrected version with new transaction time
+    INSERT INTO Party_H (
+        party_id, party_key, legal_name,
+        valid_from_dts, valid_to_dts,
+        transaction_from_dts, transaction_to_dts,
+        is_current, is_deleted
+    ) VALUES (
+        1001, 'CUST-12345', 'Jane Smith',
+        TIMESTAMP '2024-06-10 00:00:00+00:00',  -- CORRECTED valid time
+        TIMESTAMP '9999-12-31 23:59:59.999999+00:00',
+        CURRENT_TIMESTAMP(6),  -- NEW transaction time
+        TIMESTAMP '9999-12-31 23:59:59.999999+00:00',
+        1, 0
+    );
 
--- Result: Complete history preserved
--- - What we thought (2024-06-15) - closed in transaction time
--- - What actually happened (2024-06-10) - current
-```
+    -- Result: Complete history preserved
+    -- - What we thought (2024-06-15) - closed in transaction time
+    -- - What actually happened (2024-06-10) - current
 
 ### 2.5 Advocated Query Patterns
 
 #### Get Current State
 
-```sql
-SELECT party_id, party_key, legal_name
-FROM Party_H
-WHERE party_key = 'CUST-12345'
-  AND is_current = 1
-  AND is_deleted = 0;
-```
+    SELECT party_id, party_key, legal_name
+    FROM Party_H
+    WHERE party_key = 'CUST-12345'
+      AND is_current = 1
+      AND is_deleted = 0;
 
 #### Point-in-Time Query (for ML Features)
 
-```sql
--- "What was the customer's name on 2024-05-01?"
--- Critical for computing features with temporal correctness
-SELECT party_id, party_key, legal_name
-FROM Party_H
-WHERE party_key = 'CUST-12345'
-  AND TIMESTAMP '2024-05-01 00:00:00+00:00' >= valid_from_dts
-  AND TIMESTAMP '2024-05-01 00:00:00+00:00' < valid_to_dts
-  AND is_deleted = 0
-  AND transaction_from_dts = (
-      SELECT MAX(transaction_from_dts)
-      FROM Party_H p2
-      WHERE p2.party_id = Party_H.party_id
-        AND p2.transaction_from_dts <= TIMESTAMP '2024-05-01 23:59:59.999999+00:00'
-  );
-```
+    -- "What was the customer's name on 2024-05-01?"
+    -- Critical for computing features with temporal correctness
+    SELECT party_id, party_key, legal_name
+    FROM Party_H
+    WHERE party_key = 'CUST-12345'
+      AND TIMESTAMP '2024-05-01 00:00:00+00:00' >= valid_from_dts
+      AND TIMESTAMP '2024-05-01 00:00:00+00:00' < valid_to_dts
+      AND is_deleted = 0
+      AND transaction_from_dts = (
+          SELECT MAX(transaction_from_dts)
+          FROM Party_H p2
+          WHERE p2.party_id = Party_H.party_id
+            AND p2.transaction_from_dts <= TIMESTAMP '2024-05-01 23:59:59.999999+00:00'
+      );
 
 #### As-Of Query (Transaction Time)
 
-```sql
--- "What did our database show on 2024-07-15 (before correction)?"
-SELECT party_id, party_key, legal_name
-FROM Party_H
-WHERE party_key = 'CUST-12345'
-  AND transaction_from_dts <= TIMESTAMP '2024-07-15 23:59:59.999999+00:00'
-  AND transaction_to_dts > TIMESTAMP '2024-07-15 23:59:59.999999+00:00';
-```
+    -- "What did our database show on 2024-07-15 (before correction)?"
+    SELECT party_id, party_key, legal_name
+    FROM Party_H
+    WHERE party_key = 'CUST-12345'
+      AND transaction_from_dts <= TIMESTAMP '2024-07-15 23:59:59.999999+00:00'
+      AND transaction_to_dts > TIMESTAMP '2024-07-15 23:59:59.999999+00:00';
 
 ### 2.6 Alternative: Type 2 SCD (When Acceptable)
 
 **Use Type 2 SCD instead of bi-temporal when:**
+
 - Late-arriving facts are extremely rare
 - Corrections are not needed
 - ML features don't require point-in-time correctness
 - Simpler is better for your use case
 
-```sql
--- Type 2 SCD (simpler temporal)
-CREATE TABLE Party_H (
-    party_id BIGINT NOT NULL,
-    party_key VARCHAR(50) NOT NULL,
-    effective_date DATE NOT NULL,
-    expiration_date DATE NOT NULL DEFAULT DATE '9999-12-31',
-    is_current BYTEINT NOT NULL DEFAULT 1,
-    -- ... other columns ...
-);
-```
+
+    -- Type 2 SCD (simpler temporal)
+    CREATE TABLE Party_H (
+        party_id BIGINT NOT NULL,
+        party_key VARCHAR(50) NOT NULL,
+        effective_date DATE NOT NULL,
+        expiration_date DATE NOT NULL DEFAULT DATE '9999-12-31',
+        is_current BYTEINT NOT NULL DEFAULT 1,
+        -- ... other columns ...
+    );
 
 **Trade-off**: Simpler implementation, but loses ability to handle corrections and lacks transaction-time dimension.
 
@@ -301,9 +291,7 @@ CREATE TABLE Party_H (
 
 ### 3.1 The Column Overhead Challenge
 
-**Traditional Standards**: 20+ standard columns per table
-**Problem**: Significant overhead on high-volume tables
-**Advocated Solution**: Three-tier approach
+**Traditional Standards**: 20+ standard columns per table **Problem**: Significant overhead on high-volume tables **Advocated Solution**: Three-tier approach
 
 ### 3.2 Three-Tier Column Strategy
 
@@ -311,66 +299,61 @@ CREATE TABLE Party_H (
 
 **Minimum viable set for AI-Native domain tables:**
 
-```sql
-{entity}_id        BIGINT NOT NULL             -- Surrogate key
-{entity}_key       VARCHAR(50) NOT NULL        -- Natural key
-valid_from_dts      TIMESTAMP(6) WITH TIME ZONE NOT NULL
-valid_to_dts        TIMESTAMP(6) WITH TIME ZONE NOT NULL
-transaction_from_dts TIMESTAMP(6) WITH TIME ZONE NOT NULL
-transaction_to_dts   TIMESTAMP(6) WITH TIME ZONE NOT NULL
-is_current  BYTEINT NOT NULL DEFAULT 1
-is_deleted          BYTEINT NOT NULL DEFAULT 0
-```
+    {entity}_id        BIGINT NOT NULL             -- Surrogate key
+    {entity}_key       VARCHAR(50) NOT NULL        -- Natural key
+    valid_from_dts      TIMESTAMP(6) WITH TIME ZONE NOT NULL
+    valid_to_dts        TIMESTAMP(6) WITH TIME ZONE NOT NULL
+    transaction_from_dts TIMESTAMP(6) WITH TIME ZONE NOT NULL
+    transaction_to_dts   TIMESTAMP(6) WITH TIME ZONE NOT NULL
+    is_current  BYTEINT NOT NULL DEFAULT 1
+    is_deleted          BYTEINT NOT NULL DEFAULT 0
 
 **Total: 8 columns**
 
 #### Tier 2: Extended Columns (Add When Justified)
 
-```sql
--- Version tracking (if humans need it)
-version_number      INTEGER
+    -- Version tracking (if humans need it)
+    version_number      INTEGER
 
--- ID type (if multiple identifier types exist)
-{entity}_id_type    VARCHAR(20)
+    -- ID type (if multiple identifier types exist)
+    {entity}_id_type    VARCHAR(20)
 
--- Direct references to Observability (for performance)
-change_event_id    BIGINT  -- FK to Observability.ChangeEvent_H
-lineage_id         BIGINT  -- FK to Observability.DataLineage_H
-quality_id        BIGINT  -- FK to Observability.DataQuality_H
+    -- Direct references to Observability (for performance)
+    change_event_id    BIGINT  -- FK to Observability.ChangeEvent_H
+    lineage_id         BIGINT  -- FK to Observability.DataLineage_H
+    quality_id        BIGINT  -- FK to Observability.DataQuality_H
 
--- Change detection (if needed in ETL)
-record_hash         VARCHAR(64)
-```
+    -- Change detection (if needed in ETL)
+    record_hash         VARCHAR(64)
 
 **Add selectively based on need**
 
 #### Tier 3: Offload to Observability (Recommended)
 
-```sql
--- Instead of in Domain table:
-created_by, updated_by, deleted_by, deleted_reason
-source_system, source_record_id, batch_id
-data_quality_score, quality_rule_failures
+    -- Instead of in Domain table:
+    created_by, updated_by, deleted_by, deleted_reason
+    source_system, source_record_id, batch_id
+    data_quality_score, quality_rule_failures
 
--- Store in Observability module:
-Observability.ChangeEvent_H    -- Who, when, why
-Observability.DataLineage_H    -- Source tracking
-Observability.DataQuality_H    -- Quality time-series
-```
+    -- Store in Observability module:
+    Observability.ChangeEvent_H    -- Who, when, why
+    Observability.DataLineage_H    -- Source tracking
+    Observability.DataQuality_H    -- Quality time-series
 
 ### 3.3 Column Overhead Comparison
 
 | Approach | Columns | Storage Impact | Join Needed |
-|----------|---------|----------------|-------------|
+| --- | --- | --- | --- |
 | **Core Only** | 8 | Minimal | Yes (via views) |
 | **Core + FK Refs** | 11 | Low | Yes (but fast) |
 | **Core + Extended** | 15-20 | Medium | Sometimes |
 | **Traditional (all in Domain)** | 20-25 | High | No |
 
+
 ### 3.4 Advocated Approach by Table Volume
 
 | Table Volume | Advocated Approach | Rationale |
-|--------------|-------------------|-----------|
+| --- | --- | --- |
 | **< 10M rows** | Core + Extended OK | Storage overhead acceptable |
 | **10M - 100M rows** | Core + FK Refs | Balance performance and storage |
 | **> 100M rows** | Core Only + Views | Minimize overhead |
@@ -382,18 +365,18 @@ Observability.DataQuality_H    -- Quality time-series
 
 ### 4.1 Why We Advocate Surrogate Keys
 
-**Advocated**: System-generated BIGINT surrogate keys
-**Alternative**: Natural keys as primary identifier
+**Advocated**: System-generated BIGINT surrogate keys **Alternative**: Natural keys as primary identifier
 
 #### Benefits of Surrogate Keys
 
 | Benefit | Description |
-|---------|-------------|
+| --- | --- |
 | **Stability** | Never changes, even if natural key changes |
 | **Performance** | BIGINT joins faster than VARCHAR |
 | **Simplicity** | Single column vs composite natural keys |
 | **Universality** | Works for all entity types |
 | **Cross-module** | Consistent FK pattern |
+
 
 ### 4.2 Surrogate Key Stability in History Tables
 
@@ -407,15 +390,13 @@ outputs, cross-module joins — hold FK references to the entity's surrogate. If
 surrogate changes between versions, those FK references become ambiguous: which
 version's value should be stored?
 
-```
-Illustrative example: Customer 'CUST-12345' with 3 SCD versions
-  Version 1 → party_id = 1
-  Version 2 → party_id = 1   ← same surrogate (correct — separate allocation)
-  Version 3 → party_id = 1   ← same surrogate (correct — separate allocation)
+    Illustrative example: Customer 'CUST-12345' with 3 SCD versions
+      Version 1 → party_id = 1
+      Version 2 → party_id = 1   ← same surrogate (correct — separate allocation)
+      Version 3 → party_id = 1   ← same surrogate (correct — separate allocation)
 
-  A transaction table holding party_id = 1 unambiguously identifies the customer
-  regardless of which version is current.
-```
+      A transaction table holding party_id = 1 unambiguously identifies the customer
+      regardless of which version is current.
 
 When surrogate allocation is managed separately, cross-module FK joins are stable
 and unambiguous regardless of how many SCD versions exist for an entity.
@@ -434,75 +415,69 @@ If adopting the Keymap pattern, the following templates apply.
 
 #### Keymap Table DDL
 
-```sql
--- One row per unique real-world entity.
--- IDENTITY fires here once per natural key — never on the _H table.
-CREATE TABLE {ProductName}_Domain.{Entity}_Keymap (
-    {entity}_id   BIGINT GENERATED ALWAYS AS IDENTITY NOT NULL,
-    {entity}_key  VARCHAR(50) CHARACTER SET LATIN NOT CASESPECIFIC NOT NULL,
-    source_system VARCHAR(50) CHARACTER SET LATIN NOT CASESPECIFIC,
-    created_dts   TIMESTAMP(6) WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP(6)
-)
-UNIQUE PRIMARY INDEX ({entity}_key);  -- UNIQUE PI: one row per natural key
+    -- One row per unique real-world entity.
+    -- IDENTITY fires here once per natural key — never on the _H table.
+    CREATE TABLE {ProductName}_Domain.{Entity}_Keymap (
+        {entity}_id   BIGINT GENERATED ALWAYS AS IDENTITY NOT NULL,
+        {entity}_key  VARCHAR(50) CHARACTER SET LATIN NOT CASESPECIFIC NOT NULL,
+        source_system VARCHAR(50) CHARACTER SET LATIN NOT CASESPECIFIC,
+        created_dts   TIMESTAMP(6) WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP(6)
+    )
+    UNIQUE PRIMARY INDEX ({entity}_key);  -- UNIQUE PI: one row per natural key
 
-COMMENT ON TABLE {ProductName}_Domain.{Entity}_Keymap IS
-'Keymap: one row per unique {entity}. Surrogate key (IDENTITY) generated here
-and referenced by {Entity}_H and all cross-domain FK columns. Natural key is
-{entity}_key from the source system.';
-COMMENT ON COLUMN {ProductName}_Domain.{Entity}_Keymap.{entity}_id IS
-'Surrogate key - generated exactly once per real-world entity. Stable across
-all SCD versions in {Entity}_H and across all modules that reference this entity.';
-COMMENT ON COLUMN {ProductName}_Domain.{Entity}_Keymap.{entity}_key IS
-'Natural business key from the source system - used to look up the stable surrogate.';
-```
+    COMMENT ON TABLE {ProductName}_Domain.{Entity}_Keymap IS
+    'Keymap: one row per unique {entity}. Surrogate key (IDENTITY) generated here
+    and referenced by {Entity}_H and all cross-domain FK columns. Natural key is
+    {entity}_key from the source system.';
+    COMMENT ON COLUMN {ProductName}_Domain.{Entity}_Keymap.{entity}_id IS
+    'Surrogate key - generated exactly once per real-world entity. Stable across
+    all SCD versions in {Entity}_H and across all modules that reference this entity.';
+    COMMENT ON COLUMN {ProductName}_Domain.{Entity}_Keymap.{entity}_key IS
+    'Natural business key from the source system - used to look up the stable surrogate.';
 
 #### History Table DDL
 
-```sql
--- {entity}_id is BIGINT NOT NULL — populated from the keymap (or equivalent
--- allocation mechanism) via JOIN. Never generated directly on this table.
--- Multiple rows with the same {entity}_id will exist (one per SCD version).
--- PRIMARY INDEX (non-unique) co-locates all versions on the same AMP,
--- making expire-and-insert SCD operations efficient.
-CREATE TABLE {ProductName}_Domain.{Entity}_H (
-    {entity}_id   BIGINT NOT NULL,         -- from Keymap — stable across versions
-    {entity}_key  VARCHAR(50) NOT NULL,    -- natural key repeated for convenience
-    -- ... temporal and business columns ...
-    PRIMARY INDEX ({entity}_id)            -- NUPI: multiple versions allowed
-);
+    -- {entity}_id is BIGINT NOT NULL — populated from the keymap (or equivalent
+    -- allocation mechanism) via JOIN. Never generated directly on this table.
+    -- Multiple rows with the same {entity}_id will exist (one per SCD version).
+    -- PRIMARY INDEX (non-unique) co-locates all versions on the same AMP,
+    -- making expire-and-insert SCD operations efficient.
+    CREATE TABLE {ProductName}_Domain.{Entity}_H (
+        {entity}_id   BIGINT NOT NULL,         -- from Keymap — stable across versions
+        {entity}_key  VARCHAR(50) NOT NULL,    -- natural key repeated for convenience
+        -- ... temporal and business columns ...
+        PRIMARY INDEX ({entity}_id)            -- NUPI: multiple versions allowed
+    );
 
-COMMENT ON COLUMN {ProductName}_Domain.{Entity}_H.{entity}_id IS
-'Surrogate key - allocated via surrogate key allocation strategy (see Advocated
-Data Management Standards Section 4). Stable across all SCD versions for the
-same real-world entity. Never generated directly on this table.';
-```
+    COMMENT ON COLUMN {ProductName}_Domain.{Entity}_H.{entity}_id IS
+    'Surrogate key - allocated via surrogate key allocation strategy (see Advocated
+    Data Management Standards Section 4). Stable across all SCD versions for the
+    same real-world entity. Never generated directly on this table.';
 
 #### Two-Step Load Pattern (Keymap approach)
 
-```sql
--- Step 1: Register any new natural keys (idempotent — WHERE NOT EXISTS)
-INSERT INTO {ProductName}_Domain.{Entity}_Keymap ({entity}_key, source_system)
-SELECT DISTINCT TRIM(s.NATURAL_KEY_COLUMN), 'SOURCE_SYSTEM_NAME'
-FROM {source_table} s
-WHERE NOT EXISTS (
-    SELECT 1 FROM {ProductName}_Domain.{Entity}_Keymap k
-    WHERE k.{entity}_key = TRIM(s.NATURAL_KEY_COLUMN)
-);
+    -- Step 1: Register any new natural keys (idempotent — WHERE NOT EXISTS)
+    INSERT INTO {ProductName}_Domain.{Entity}_Keymap ({entity}_key, source_system)
+    SELECT DISTINCT TRIM(s.NATURAL_KEY_COLUMN), 'SOURCE_SYSTEM_NAME'
+    FROM {source_table} s
+    WHERE NOT EXISTS (
+        SELECT 1 FROM {ProductName}_Domain.{Entity}_Keymap k
+        WHERE k.{entity}_key = TRIM(s.NATURAL_KEY_COLUMN)
+    );
 
--- Step 2: Populate history table using keymap JOIN
-INSERT INTO {ProductName}_Domain.{Entity}_H (
-    {entity}_id, {entity}_key, /* business columns */,
-    valid_from_dts, valid_to_dts, is_current, is_deleted
-)
-SELECT
-    k.{entity}_id,               -- stable surrogate from keymap
-    TRIM(s.NATURAL_KEY_COLUMN),
-    /* business columns */,
-    CURRENT_TIMESTAMP(6), TIMESTAMP '9999-12-31 23:59:59.999999+00:00', 1, 0
-FROM {source_table}                              s
-JOIN {ProductName}_Domain.{Entity}_Keymap        k
-    ON k.{entity}_key = TRIM(s.NATURAL_KEY_COLUMN);
-```
+    -- Step 2: Populate history table using keymap JOIN
+    INSERT INTO {ProductName}_Domain.{Entity}_H (
+        {entity}_id, {entity}_key, /* business columns */,
+        valid_from_dts, valid_to_dts, is_current, is_deleted
+    )
+    SELECT
+        k.{entity}_id,               -- stable surrogate from keymap
+        TRIM(s.NATURAL_KEY_COLUMN),
+        /* business columns */,
+        CURRENT_TIMESTAMP(6), TIMESTAMP '9999-12-31 23:59:59.999999+00:00', 1, 0
+    FROM {source_table}                              s
+    JOIN {ProductName}_Domain.{Entity}_Keymap        k
+        ON k.{entity}_key = TRIM(s.NATURAL_KEY_COLUMN);
 
 #### Cross-Entity Foreign Keys
 
@@ -510,74 +485,69 @@ Regardless of the surrogate key allocation mechanism chosen, all FK references
 between domain entities should point to the **stable surrogate**, not to a specific
 row in the `_H` table, to ensure FK joins are unambiguous across SCD versions.
 
-```sql
--- FK columns in other entities reference the stable surrogate
-CREATE TABLE {ProductName}_Domain.Order_H (
-    order_id    BIGINT NOT NULL,
-    party_id    BIGINT,     -- FK to Party stable surrogate (e.g. via Party_Keymap)
-    product_id  BIGINT,     -- FK to Product stable surrogate
-    -- ...
-);
-```
+    -- FK columns in other entities reference the stable surrogate
+    CREATE TABLE {ProductName}_Domain.Order_H (
+        order_id    BIGINT NOT NULL,
+        party_id    BIGINT,     -- FK to Party stable surrogate (e.g. via Party_Keymap)
+        product_id  BIGINT,     -- FK to Product stable surrogate
+        -- ...
+    );
 
 ### 4.4 Reference and Lookup Table Exemption
 
-The surrogate key stability requirement applies to entities whose surrogate is
-**referenced as a foreign key by other tables**. Reference and lookup tables, as
+The surrogate key stability requirement applies to entities whose surrogate is **referenced as a foreign key by other tables**. Reference and lookup tables, as
 well as detail/child entities that are never themselves FK-referenced, do not need a
 separate allocation mechanism — a simple IDENTITY column directly on the `_H` table
 is sufficient, since no external table holds a reference to their surrogate across
 SCD versions.
 
-```
-Stable allocation required           Simple IDENTITY on _H acceptable
-----------------------------------   ------------------------------------------
-Party   (FK target of Order)         Reference tables  (e.g. LoanPurpose_R)
-Order   (FK target of LineItem)      Lookup tables     (e.g. StatusCode_R)
-Product (FK target of Order)         Detail/child entities with no FK dependants
-                                     (e.g. CustomerContact, PropertyRisk)
-```
+    Stable allocation required           Simple IDENTITY on _H acceptable
+    ----------------------------------   ------------------------------------------
+    Party   (FK target of Order)         Reference tables  (e.g. LoanPurpose_R)
+    Order   (FK target of LineItem)      Lookup tables     (e.g. StatusCode_R)
+    Product (FK target of Order)         Detail/child entities with no FK dependants
+                                         (e.g. CustomerContact, PropertyRisk)
 
 **Rule**: Does any other table hold a FK column pointing to this entity's surrogate?
+
 - YES → A surrogate allocation strategy is recommended to ensure FK stability across SCD versions
-- NO  → Simple IDENTITY on `_H` is sufficient
+- NO → Simple IDENTITY on `_H` is sufficient
+
 
 ### 4.5 Surrogate Key Allocation Decision Tree
 
-```
-START: Is this entity's surrogate referenced as a FK by any other table?
-|
-+-- YES --> Surrogate allocation strategy required
-|           Options (choose one):
-|           a) Keymap pattern (recommended in this document)
-|           b) Organisation's existing central key allocation standard
-|           c) Database sequence with natural key constraint on _H
-|           Key principle: the surrogate must be stable across SCD versions
-|
-+-- NO  --> Reference/lookup table or detail entity: IDENTITY on _H is acceptable
-            - {entity}_id = BIGINT GENERATED ALWAYS AS IDENTITY on _H
-            - Single-step INSERT; no prior allocation step needed
-            - Document explicitly that this entity is not a FK target
-```
+    START: Is this entity's surrogate referenced as a FK by any other table?
+    |
+    +-- YES --> Surrogate allocation strategy required
+    |           Options (choose one):
+    |           a) Keymap pattern (recommended in this document)
+    |           b) Organisation's existing central key allocation standard
+    |           c) Database sequence with natural key constraint on _H
+    |           Key principle: the surrogate must be stable across SCD versions
+    |
+    +-- NO  --> Reference/lookup table or detail entity: IDENTITY on _H is acceptable
+                - {entity}_id = BIGINT GENERATED ALWAYS AS IDENTITY on _H
+                - Single-step INSERT; no prior allocation step needed
+                - Document explicitly that this entity is not a FK target
 
 ### 4.6 When Natural Keys Are Acceptable as the Surrogate
 
 **Use natural key as surrogate when:**
+
 - Natural key is truly immutable
 - Natural key is single column
 - Natural key is numeric (not VARCHAR)
 - Business strongly prefers it
 
+
 **Example**: Product SKU that never changes
 
-```sql
-CREATE TABLE Product_H (
-    product_id BIGINT NOT NULL,  -- Still use surrogate internally
-    sku        VARCHAR(20) NOT NULL,
-    -- ...
-    PRIMARY INDEX (product_id)
-);
-```
+    CREATE TABLE Product_H (
+        product_id BIGINT NOT NULL,  -- Still use surrogate internally
+        sku        VARCHAR(20) NOT NULL,
+        -- ...
+        PRIMARY INDEX (product_id)
+    );
 
 ---
 
@@ -585,13 +555,12 @@ CREATE TABLE Product_H (
 
 ### 5.1 Why We Advocate Soft Deletes
 
-**Hard Delete**: `DELETE FROM Party_H WHERE party_id = 1001`
-**Soft Delete**: `UPDATE Party_H SET is_deleted = 1 WHERE party_id = 1001`
+**Hard Delete**: `DELETE FROM Party_H WHERE party_id = 1001` **Soft Delete**: `UPDATE Party_H SET is_deleted = 1 WHERE party_id = 1001`
 
 #### Benefits for AI-Native Data Products
 
 | Benefit | Description |
-|---------|-------------|
+| --- | --- |
 | **Audit trail** | Complete history preserved |
 | **Explainability** | "Why did model predict X?" requires historical state |
 | **Regulatory compliance** | GDPR, CCPA require audit trails |
@@ -599,196 +568,351 @@ CREATE TABLE Product_H (
 | **Analytics** | Churn analysis, deletion patterns |
 | **ML features** | "Was customer deleted" is a feature |
 
+
 ### 5.2 Advocated Soft Delete Implementation
 
-```sql
--- Core column
-is_deleted BYTEINT NOT NULL DEFAULT 0
-    COMMENT '0 = Active, 1 = Soft deleted'
+    -- Core column
+    is_deleted BYTEINT NOT NULL DEFAULT 0
+        COMMENT '0 = Active, 1 = Soft deleted'
 
--- Optional: Store deletion details in Domain table
-deleted_by VARCHAR(100)
-    COMMENT 'User/system that soft deleted this record'
-deleted_dts TIMESTAMP(6) WITH TIME ZONE
-    COMMENT 'When this record was soft deleted'
-deleted_reason VARCHAR(500)
-    COMMENT 'Reason for soft delete (GDPR, data quality, etc.)'
+    -- Optional: Store deletion details in Domain table
+    deleted_by VARCHAR(100)
+        COMMENT 'User/system that soft deleted this record'
+    deleted_dts TIMESTAMP(6) WITH TIME ZONE
+        COMMENT 'When this record was soft deleted'
+    deleted_reason VARCHAR(500)
+        COMMENT 'Reason for soft delete (GDPR, data quality, etc.)'
 
--- Better: Store deletion details in Observability
--- (see Section 6)
-```
+    -- Better: Store deletion details in Observability
+    -- (see Section 7)
 
 ### 5.3 Soft Delete Operation
 
-```sql
--- Step 1: Close out current version
-UPDATE Party_H
-SET valid_to_dts = CURRENT_TIMESTAMP(6),
-    transaction_to_dts = CURRENT_TIMESTAMP(6),
-    is_current = 0
-WHERE party_id = 1001
-  AND is_current = 1;
+    -- Step 1: Close out current version
+    UPDATE Party_H
+    SET valid_to_dts = CURRENT_TIMESTAMP(6),
+        transaction_to_dts = CURRENT_TIMESTAMP(6),
+        is_current = 0
+    WHERE party_id = 1001
+      AND is_current = 1;
 
--- Step 2: Insert soft-deleted version
-INSERT INTO Party_H (
-    party_id, party_key, legal_name,
-    valid_from_dts, valid_to_dts,
-    transaction_from_dts, transaction_to_dts,
-    is_current, is_deleted
-) VALUES (
-    1001, 'CUST-12345', 'Jane Smith',
-    CURRENT_TIMESTAMP(6),  -- Deleted as of now
-    TIMESTAMP '9999-12-31 23:59:59.999999+00:00',
-    CURRENT_TIMESTAMP(6),
-    TIMESTAMP '9999-12-31 23:59:59.999999+00:00',
-    1,  -- is_current = 1 (this IS the current state: deleted)
-    1   -- is_deleted = 1
-);
+    -- Step 2: Insert soft-deleted version
+    INSERT INTO Party_H (
+        party_id, party_key, legal_name,
+        valid_from_dts, valid_to_dts,
+        transaction_from_dts, transaction_to_dts,
+        is_current, is_deleted
+    ) VALUES (
+        1001, 'CUST-12345', 'Jane Smith',
+        CURRENT_TIMESTAMP(6),  -- Deleted as of now
+        TIMESTAMP '9999-12-31 23:59:59.999999+00:00',
+        CURRENT_TIMESTAMP(6),
+        TIMESTAMP '9999-12-31 23:59:59.999999+00:00',
+        1,  -- is_current = 1 (this IS the current state: deleted)
+        1   -- is_deleted = 1
+    );
 
--- Track deletion details in Observability
-INSERT INTO Observability.ChangeEvent_H (
-    entity_type, entity_id, change_type,
-    changed_by, changed_dts, change_reason
-) VALUES (
-    'PARTY', 1001, 'DELETE',
-    'DELETE_PROCESS', CURRENT_TIMESTAMP(6), 'GDPR Right to be Forgotten'
-);
-```
+    -- Track deletion details in Observability
+    INSERT INTO Observability.ChangeEvent_H (
+        entity_type, entity_id, change_type,
+        changed_by, changed_dts, change_reason
+    ) VALUES (
+        'PARTY', 1001, 'DELETE',
+        'DELETE_PROCESS', CURRENT_TIMESTAMP(6), 'GDPR Right to be Forgotten'
+    );
 
 ### 5.4 Querying with Soft Deletes
 
-```sql
--- Current active records only (most common)
-SELECT * FROM Party_H
-WHERE is_current = 1
-  AND is_deleted = 0;
+    -- Current active records only (most common)
+    SELECT * FROM Party_H
+    WHERE is_current = 1
+      AND is_deleted = 0;
 
--- Include deleted records
-SELECT * FROM Party_H
-WHERE is_current = 1;
+    -- Include deleted records
+    SELECT * FROM Party_H
+    WHERE is_current = 1;
 
--- Only deleted records
-SELECT * FROM Party_H
-WHERE is_current = 1
-  AND is_deleted = 1;
-```
+    -- Only deleted records
+    SELECT * FROM Party_H
+    WHERE is_current = 1
+      AND is_deleted = 1;
 
 ### 5.5 When Hard Deletes Are Acceptable
 
 **Use hard deletes when:**
+
 - No regulatory audit requirement
 - No ML feature dependency
 - No analytics on deletion patterns
 - Storage constraints are critical
 - Data truly has no future value
 
+
 **Example**: Temporary staging data, test data
 
 ---
 
-## 6. Observability Offload Pattern
+## 6. Access Layer
 
-### 6.1 The Normalization Principle
+### 6.1 Why We Advocate Reading Through Views
+
+**Traditional Approach**: Consumers — analysts, applications, BI
+tools, agents — read tables directly, managing lock posture and
+column projection in every query.
+
+**Advocated Approach**: Tables are not the consumer surface.
+Every table that is read by anything other than its load process
+and DBAs is fronted by a view. Consumers read the view; the table
+is private.
+
+#### Key Benefits for AI-Native Data Products
+
+| Concern                        | Direct table reads          | Read through views      |
+| ------------------------------ | --------------------------- | ----------------------- |
+| **Concurrent loads**           | ⚠️ Read can block load      | ✅ Read is non-blocking |
+| **Lock posture consistency**   | ⚠️ Per-query, easy to omit  | ✅ Centralised in view  |
+| **Agent discoverability**      | ⚠️ Physical schema exposed  | ✅ Stable contract      |
+| **Permission management**      | ⚠️ Coupled to physical      | ✅ Decoupled            |
+| **Refactoring physical layer** | ❌ Breaks every consumer    | ✅ View absorbs change  |
+| **Schema documentation**       | ⚠️ Scattered                | ✅ Co-located in view   |
+
+The view layer is the **stable contract** between physical data
+and every consumer. As long as the contract holds, the underlying
+table can be re-partitioned, re-indexed, re-located, or
+re-modelled without breaking a single consumer. For AI-Native
+Data Products specifically, this stability is what allows an
+agent to learn a data product once and continue to operate
+correctly as its physical implementation evolves.
+
+### 6.2 Defer to the Object Placement Standard
+
+This document is deliberately silent on **where** tables and
+views are placed, **how** containers are named, and **how**
+access is granted across them. Those decisions are governed by a
+separate, layered standards system:
+
+| Document                                                | Role                                                                                                       |
+| ------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| **Object Placement Standard — Interface Specification** | Platform-agnostic contract. Defines the eight required sections any conforming placement standard must declare. |
+| **Object Placement Standard — Platform Implementation** | A conforming implementation for a specific platform (e.g. Teradata). Declares concrete naming, separation, view-tier architecture, access model, and validation procedure. |
+
+This document **advocates** access through views. The Object
+Placement Standard **prescribes** how that access is structured
+on a given platform. The split is intentional:
+
+- **Different organisations have different conventions.** Some
+  separate tables and views into distinct containers; some
+  co-locate them; some apply a layered zone model. All can be
+  conformant.
+- **The agent contract must be portable.** An AI-Native Data
+  Product agent reads a conforming Object Placement Standard
+  before generating any DDL. It does not assume — it reads, it
+  derives, it validates. The contract is the same shape on every
+  platform; the implementation differs.
+- **This document advocates patterns; the Object Placement
+  Standard prescribes structure.** Conflating the two would force
+  every reader to either adopt a single naming convention or
+  rewrite parts of this document — neither of which is
+  appropriate for an advocacy document.
+
+#### Agent and Builder Behaviour
+
+A data product builder, or an agent generating DDL within a data
+product, **must locate a conforming Object Placement Standard
+implementation before generating any object**. The Interface
+Specification defines the priority order for locating it:
+
+1. An explicit file path provided in conversation or project
+   instructions
+2. A skill file at a well-known path (e.g.
+   `/mnt/skills/user/object-placement/SKILL.md`)
+3. A file matching `Object_Placement_Standard*.md` in project
+   context
+4. **If none are present:** halt and ask the user
+
+A builder must never default to a placement convention,
+substitute its own assumption, or fall back to "the most common
+pattern". If the standard is absent, the correct response is to
+ask, not to guess.
+
+### 6.3 What This Document Continues to Cover
+
+The Object Placement Standard governs container structure,
+naming, separation, and access. This document continues to
+advocate **logical patterns** that are independent of placement:
+
+- Bi-temporal columns and their semantics (Section 2)
+- Column tiering and offload to Observability (Section 3)
+- Surrogate key strategy and the Keymap pattern (Section 4)
+- Soft-delete semantics (Section 5)
+- Observability offload pattern (Section 7)
+- Timezone handling (Section 8)
+- Data quality scoring (Section 9)
+- Audit trail strategy (Section 10)
+
+These patterns are **expressed in DDL** that the Object Placement
+Standard then places into the appropriate containers. The two
+standards compose: this document advocates *what* a `Customer_H`
+table contains; the Object Placement Standard determines *which
+container* `Customer_H` and its fronting view are placed in, what
+they are named, and how they are accessed.
+
+#### Worked Example of the Composition
+
+A `Customer_H` table designed under this document has bi-temporal
+columns (Section 2), a stable surrogate from a Keymap (Section
+4), and a soft-delete flag (Section 5). The Object Placement
+Standard then determines:
+
+- The container the table is placed in (e.g. a strict-separation
+  Teradata implementation places it in a `_T` container)
+- The container the fronting locking view is placed in (e.g. the
+  matching `_V` container under strict separation, or the same
+  container under co-location)
+- The exact name of each container, derived from the standard's
+  `derive_container()` function
+- The access grants and any implied grants required by the
+  separation architecture
+- The validation procedure that confirms placement after
+  deployment
+
+Neither document is complete on its own. Together they describe a
+fully-specified data product.
+
+### 6.4 Why This Is Agent-Friendly
+
+The split between *what to design* (this document) and *where to
+place it* (the Object Placement Standard) is what makes the
+combined system robust under agent operation. Three properties
+follow:
+
+**Portability across customers.** An agent that builds data
+products for multiple customers does not carry hard-coded
+placement assumptions. It carries a contract — read the
+Placement Standard, call its derivation function, run its
+validation procedure — and renders correctly into whatever
+convention the customer has chosen.
+
+**Stability under physical change.** A customer reorganising
+their container hierarchy revises one document — their Object
+Placement Standard. Every data product designed under this
+document continues to apply unchanged.
+
+**Independent evolution.** This document evolves as data
+management practices evolve (new bi-temporal patterns, new
+quality scoring approaches). Placement standards evolve as
+platform capabilities evolve (new container types, new access
+mechanisms). Neither blocks the other.
+
+### 6.5 Reference
+
+| Document                                                | Location                                                                                                            |
+| ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| **Object Placement Standard — Interface Specification** | [`platform-standards/Object_Placement_Standard_Spec.md`](../platform-standards/Object_Placement_Standard_Spec.md) — platform-agnostic; the contract |
+| **Teradata reference implementation**                   | [`standards/Object_Placement_Standard_Teradata.md`](https://github.com/remi-td/data-products-builder/blob/main/standards/Object_Placement_Standard_Teradata.md) — conforming implementation; one of several possible |
+
+Implementations for other platforms (Snowflake, BigQuery,
+Databricks, etc.) follow the same Interface Specification with
+platform-appropriate constructs. Any organisation may author its
+own conforming implementation that reflects local conventions.
+
+---
+
+## 7. Observability Offload Pattern
+
+### 7.1 The Normalization Principle
 
 **Problem**: Storing audit/lineage/quality data in Domain tables duplicates data across millions of rows
 
 **Advocated Solution**: Store once in Observability module, join when needed
 
-### 6.2 Observability Module Tables
+### 7.2 Observability Module Tables
 
 #### ChangeEvent_H (Audit Trail)
 
-```sql
-CREATE TABLE Observability.ChangeEvent_H (
-    change_event_id     BIGINT NOT NULL,
-    entity_type         VARCHAR(50) NOT NULL,  -- 'PARTY', 'PRODUCT', etc.
-    entity_id          BIGINT NOT NULL,
-    change_type         VARCHAR(20) NOT NULL,  -- 'INSERT', 'UPDATE', 'DELETE'
-    changed_by          VARCHAR(100) NOT NULL,
-    changed_dts         TIMESTAMP(6) WITH TIME ZONE NOT NULL,
-    change_reason       VARCHAR(500),
-    changed_columns     VARCHAR(2000),  -- JSON array of changed columns
-    old_values_json     JSON,
-    new_values_json     JSON,
-    PRIMARY INDEX (entity_id, changed_dts)
-)
-PARTITION BY RANGE_N(
-    changed_dts BETWEEN DATE '2020-01-01' AND DATE '2030-12-31' 
-    EACH INTERVAL '1' MONTH
-);
-```
+    CREATE TABLE Observability.ChangeEvent_H (
+        change_event_id     BIGINT NOT NULL,
+        entity_type         VARCHAR(50) NOT NULL,  -- 'PARTY', 'PRODUCT', etc.
+        entity_id          BIGINT NOT NULL,
+        change_type         VARCHAR(20) NOT NULL,  -- 'INSERT', 'UPDATE', 'DELETE'
+        changed_by          VARCHAR(100) NOT NULL,
+        changed_dts         TIMESTAMP(6) WITH TIME ZONE NOT NULL,
+        change_reason       VARCHAR(500),
+        changed_columns     VARCHAR(2000),  -- JSON array of changed columns
+        old_values_json     JSON,
+        new_values_json     JSON,
+        PRIMARY INDEX (entity_id, changed_dts)
+    )
+    PARTITION BY RANGE_N(
+        changed_dts BETWEEN DATE '2020-01-01' AND DATE '2030-12-31'
+        EACH INTERVAL '1' MONTH
+    );
 
 #### DataLineage_H (Source Tracking)
 
-```sql
-CREATE TABLE Observability.DataLineage_H (
-    lineage_id         BIGINT NOT NULL,
-    entity_type         VARCHAR(50) NOT NULL,
-    entity_id          BIGINT NOT NULL,
-    source_system       VARCHAR(50) NOT NULL,
-    source_record_id    VARCHAR(100),
-    batch_id            VARCHAR(50),
-    loaded_dts          TIMESTAMP(6) WITH TIME ZONE NOT NULL,
-    extraction_dts      TIMESTAMP(6) WITH TIME ZONE,
-    transformation_name VARCHAR(128),
-    lineage_metadata_json JSON,
-    PRIMARY INDEX (entity_id)
-);
-```
+    CREATE TABLE Observability.DataLineage_H (
+        lineage_id         BIGINT NOT NULL,
+        entity_type         VARCHAR(50) NOT NULL,
+        entity_id          BIGINT NOT NULL,
+        source_system       VARCHAR(50) NOT NULL,
+        source_record_id    VARCHAR(100),
+        batch_id            VARCHAR(50),
+        loaded_dts          TIMESTAMP(6) WITH TIME ZONE NOT NULL,
+        extraction_dts      TIMESTAMP(6) WITH TIME ZONE,
+        transformation_name VARCHAR(128),
+        lineage_metadata_json JSON,
+        PRIMARY INDEX (entity_id)
+    );
 
 #### DataQuality_H (Quality Time-Series)
 
-```sql
-CREATE TABLE Observability.DataQuality_H (
-    quality_id         BIGINT NOT NULL,
-    entity_type         VARCHAR(50) NOT NULL,
-    entity_id          BIGINT NOT NULL,
-    evaluated_dts       TIMESTAMP(6) WITH TIME ZONE NOT NULL,
-    quality_score       DECIMAL(3,2) NOT NULL,
-    rule_results_json   JSON,  -- Array of {rule_id, passed, message}
-    PRIMARY INDEX (entity_id, evaluated_dts)
-)
-PARTITION BY RANGE_N(
-    evaluated_dts BETWEEN DATE '2024-01-01' AND DATE '2030-12-31' 
-    EACH INTERVAL '1' MONTH
-);
-```
+    CREATE TABLE Observability.DataQuality_H (
+        quality_id         BIGINT NOT NULL,
+        entity_type         VARCHAR(50) NOT NULL,
+        entity_id          BIGINT NOT NULL,
+        evaluated_dts       TIMESTAMP(6) WITH TIME ZONE NOT NULL,
+        quality_score       DECIMAL(3,2) NOT NULL,
+        rule_results_json   JSON,  -- Array of {rule_id, passed, message}
+        PRIMARY INDEX (entity_id, evaluated_dts)
+    )
+    PARTITION BY RANGE_N(
+        evaluated_dts BETWEEN DATE '2024-01-01' AND DATE '2030-12-31'
+        EACH INTERVAL '1' MONTH
+    );
 
-### 6.3 Two Join Approaches
+### 7.3 Two Join Approaches
 
 #### Approach 1: Surrogate Key References (Fastest)
 
 **Domain table includes FK to Observability:**
 
-```sql
-CREATE TABLE Party_H (
-    party_id BIGINT NOT NULL,
-    -- ... core columns ...
-    
-    -- Optional: Direct references for performance
-    change_event_id BIGINT,  -- FK to most recent ChangeEvent
-    lineage_id BIGINT,       -- FK to current DataLineage
-    quality_id BIGINT,       -- FK to latest DataQuality
-    
-    FOREIGN KEY (change_event_id) 
-        REFERENCES Observability.ChangeEvent_H(change_event_id),
-    FOREIGN KEY (lineage_id) 
-        REFERENCES Observability.DataLineage_H(lineage_id),
-    FOREIGN KEY (quality_id) 
-        REFERENCES Observability.DataQuality_H(quality_id)
-);
+    CREATE TABLE Party_H (
+        party_id BIGINT NOT NULL,
+        -- ... core columns ...
+  
+        -- Optional: Direct references for performance
+        change_event_id BIGINT,  -- FK to most recent ChangeEvent
+        lineage_id BIGINT,       -- FK to current DataLineage
+        quality_id BIGINT,       -- FK to latest DataQuality
+  
+        FOREIGN KEY (change_event_id)
+            REFERENCES Observability.ChangeEvent_H(change_event_id),
+        FOREIGN KEY (lineage_id)
+            REFERENCES Observability.DataLineage_H(lineage_id),
+        FOREIGN KEY (quality_id)
+            REFERENCES Observability.DataQuality_H(quality_id)
+    );
 
--- Query: Fast direct join
-SELECT p.*, ce.changed_by, dl.source_system, dq.quality_score
-FROM Party_H p
-LEFT JOIN Observability.ChangeEvent_H ce 
-    ON ce.change_event_id = p.change_event_id
-LEFT JOIN Observability.DataLineage_H dl 
-    ON dl.lineage_id = p.lineage_id
-LEFT JOIN Observability.DataQuality_H dq 
-    ON dq.quality_id = p.quality_id
-WHERE p.is_current = 1;
-```
+    -- Query: Fast direct join
+    SELECT p.*, ce.changed_by, dl.source_system, dq.quality_score
+    FROM Party_H p
+    LEFT JOIN Observability.ChangeEvent_H ce
+        ON ce.change_event_id = p.change_event_id
+    LEFT JOIN Observability.DataLineage_H dl
+        ON dl.lineage_id = p.lineage_id
+    LEFT JOIN Observability.DataQuality_H dq
+        ON dq.quality_id = p.quality_id
+    WHERE p.is_current = 1;
 
 **Overhead**: 3 BIGINT columns (24 bytes) vs 15+ columns (500+ bytes)
 
@@ -796,263 +920,247 @@ WHERE p.is_current = 1;
 
 **Domain table has NO FK, join on entity_id + entity_type:**
 
-```sql
-CREATE TABLE Party_H (
-    party_id BIGINT NOT NULL,
-    -- ... core columns only (8 columns) ...
-);
+    CREATE TABLE Party_H (
+        party_id BIGINT NOT NULL,
+        -- ... core columns only (8 columns) ...
+    );
 
--- Query: Join by entity reference
-SELECT p.*, ce.changed_by, dl.source_system, dq.quality_score
-FROM Party_H p
-LEFT JOIN (
-    SELECT entity_id, changed_by, changed_dts,
-           ROW_NUMBER() OVER (PARTITION BY entity_id ORDER BY changed_dts DESC) AS rn
-    FROM Observability.ChangeEvent_H
-    WHERE entity_type = 'PARTY'
-) ce ON ce.entity_id = p.party_id AND ce.rn = 1
-LEFT JOIN Observability.DataLineage_H dl
-    ON dl.entity_type = 'PARTY' AND dl.entity_id = p.party_id
-LEFT JOIN (
-    SELECT entity_id, quality_score, evaluated_dts,
-           ROW_NUMBER() OVER (PARTITION BY entity_id ORDER BY evaluated_dts DESC) AS rn
-    FROM Observability.DataQuality_H
-    WHERE entity_type = 'PARTY'
-) dq ON dq.entity_id = p.party_id AND dq.rn = 1
-WHERE p.is_current = 1;
-```
+    -- Query: Join by entity reference
+    SELECT p.*, ce.changed_by, dl.source_system, dq.quality_score
+    FROM Party_H p
+    LEFT JOIN (
+        SELECT entity_id, changed_by, changed_dts,
+               ROW_NUMBER() OVER (PARTITION BY entity_id ORDER BY changed_dts DESC) AS rn
+        FROM Observability.ChangeEvent_H
+        WHERE entity_type = 'PARTY'
+    ) ce ON ce.entity_id = p.party_id AND ce.rn = 1
+    LEFT JOIN Observability.DataLineage_H dl
+        ON dl.entity_type = 'PARTY' AND dl.entity_id = p.party_id
+    LEFT JOIN (
+        SELECT entity_id, quality_score, evaluated_dts,
+               ROW_NUMBER() OVER (PARTITION BY entity_id ORDER BY evaluated_dts DESC) AS rn
+        FROM Observability.DataQuality_H
+        WHERE entity_type = 'PARTY'
+    ) dq ON dq.entity_id = p.party_id AND dq.rn = 1
+    WHERE p.is_current = 1;
 
 **Overhead**: 0 additional columns, join on indexed columns
 
-### 6.4 Pre-Joined Views for Agent Access
+### 7.4 Pre-Joined Views for Agent Access
 
-```sql
--- Create view to simplify agent queries
-CREATE VIEW Party_Complete AS
-SELECT 
-    p.party_id, p.party_key, p.legal_name,
-    p.valid_from_dts, p.valid_to_dts,
-    ce.changed_by AS last_changed_by,
-    ce.changed_dts AS last_changed_dts,
-    ce.change_reason,
-    dl.source_system,
-    dl.batch_id,
-    dq.quality_score,
-    dq.evaluated_dts AS quality_evaluated_dts
-FROM Party_H p
-LEFT JOIN Observability.ChangeEvent_H ce 
-    ON ce.change_event_id = p.change_event_id  -- If using FK approach
-LEFT JOIN Observability.DataLineage_H dl 
-    ON dl.lineage_id = p.lineage_id
-LEFT JOIN Observability.DataQuality_H dq 
-    ON dq.quality_id = p.quality_id
-WHERE p.is_current = 1;
+    -- Create view to simplify agent queries
+    CREATE VIEW Party_Complete AS
+    SELECT
+        p.party_id, p.party_key, p.legal_name,
+        p.valid_from_dts, p.valid_to_dts,
+        ce.changed_by AS last_changed_by,
+        ce.changed_dts AS last_changed_dts,
+        ce.change_reason,
+        dl.source_system,
+        dl.batch_id,
+        dq.quality_score,
+        dq.evaluated_dts AS quality_evaluated_dts
+    FROM Party_H p
+    LEFT JOIN Observability.ChangeEvent_H ce
+        ON ce.change_event_id = p.change_event_id  -- If using FK approach
+    LEFT JOIN Observability.DataLineage_H dl
+        ON dl.lineage_id = p.lineage_id
+    LEFT JOIN Observability.DataQuality_H dq
+        ON dq.quality_id = p.quality_id
+    WHERE p.is_current = 1;
 
--- Agent query (simple)
-SELECT * FROM Party_Complete WHERE party_key = 'CUST-12345';
-```
+    -- Agent query (simple)
+    SELECT * FROM Party_Complete WHERE party_key = 'CUST-12345';
 
-### 6.5 Advocated Approach by Scenario
+### 7.5 Advocated Approach by Scenario
 
 | Scenario | Recommended Approach |
-|----------|---------------------|
+| --- | --- |
 | **High-volume tables (>100M rows)** | No FK, join by entity_id, use views |
 | **Medium-volume (10M-100M)** | FK references for performance |
 | **Low-volume (<10M)** | Either approach acceptable |
 | **Agent-heavy workload** | Pre-joined views essential |
 | **Storage-constrained** | No FK, offload everything |
 
-### 6.6 Benefits Quantification
+
+### 7.6 Benefits Quantification
 
 **Example: 50M row Party table**
 
 | Approach | Domain Table Size | Join Performance | Complexity |
-|----------|-------------------|------------------|------------|
+| --- | --- | --- | --- |
 | **Traditional (all in Domain)** | ~10 GB | N/A (no join) | Low |
 | **Core + FK refs** | ~6 GB | Fast (direct FK) | Medium |
 | **Core only + views** | ~4 GB | Fast (indexed) | Medium |
+
 
 **Storage savings**: 40-60% while maintaining query performance
 
 ---
 
-## 7. Timezone Handling
+## 8. Timezone Handling
 
-### 7.1 Why We Advocate TIMESTAMP WITH TIME ZONE
+### 8.1 Why We Advocate TIMESTAMP WITH TIME ZONE
 
-**Problem**: Global enterprises operate across multiple timezones
-**Impact**: Temporal accuracy, regulatory compliance, cross-region analysis
+**Problem**: Global enterprises operate across multiple timezones **Impact**: Temporal accuracy, regulatory compliance, cross-region analysis
 
-### 7.2 Advocated Standard
+### 8.2 Advocated Standard
 
 **Always use `TIMESTAMP(6) WITH TIME ZONE` for all temporal columns**
 
-```sql
--- ADVOCATED
-valid_from_dts      TIMESTAMP(6) WITH TIME ZONE NOT NULL
-valid_to_dts        TIMESTAMP(6) WITH TIME ZONE NOT NULL
-transaction_from_dts TIMESTAMP(6) WITH TIME ZONE NOT NULL
-transaction_to_dts   TIMESTAMP(6) WITH TIME ZONE NOT NULL
+    -- ADVOCATED
+    valid_from_dts      TIMESTAMP(6) WITH TIME ZONE NOT NULL
+    valid_to_dts        TIMESTAMP(6) WITH TIME ZONE NOT NULL
+    transaction_from_dts TIMESTAMP(6) WITH TIME ZONE NOT NULL
+    transaction_to_dts   TIMESTAMP(6) WITH TIME ZONE NOT NULL
 
--- NOT RECOMMENDED
-valid_from_dts      TIMESTAMP(6) NOT NULL  -- Missing timezone
-```
+    -- NOT RECOMMENDED
+    valid_from_dts      TIMESTAMP(6) NOT NULL  -- Missing timezone
 
-### 7.3 Default Values with Timezone
+### 8.3 Default Values with Timezone
 
-```sql
--- Always include timezone in defaults
-DEFAULT TIMESTAMP '9999-12-31 23:59:59.999999+00:00'  -- UTC
+    -- Always include timezone in defaults
+    DEFAULT TIMESTAMP '9999-12-31 23:59:59.999999+00:00'  -- UTC
 
--- NOT
-DEFAULT TIMESTAMP '9999-12-31 23:59:59.999999'  -- Ambiguous
-```
+    -- NOT
+    DEFAULT TIMESTAMP '9999-12-31 23:59:59.999999'  -- Ambiguous
 
-### 7.4 Timezone Best Practices
+### 8.4 Timezone Best Practices
 
 | Practice | Recommendation |
-|----------|---------------|
+| --- | --- |
 | **Storage** | Always store in UTC (+00:00) |
 | **Display** | Convert to user's local timezone in application |
 | **Defaults** | Use UTC for all default timestamps |
 | **Queries** | Include explicit timezone in literals |
 | **Comparison** | Database handles timezone conversion automatically |
 
-### 7.5 Query Examples with Timezone
 
-```sql
--- Correct: Explicit timezone
-SELECT * FROM Party_H
-WHERE valid_from_dts >= TIMESTAMP '2024-01-01 00:00:00+00:00'
-  AND valid_from_dts < TIMESTAMP '2024-02-01 00:00:00+00:00';
+### 8.5 Query Examples with Timezone
 
--- Also correct: Database will convert to UTC
-SELECT * FROM Party_H
-WHERE valid_from_dts >= TIMESTAMP '2024-01-01 00:00:00-05:00'  -- EST
-  AND valid_from_dts < TIMESTAMP '2024-02-01 00:00:00-05:00';
+    -- Correct: Explicit timezone
+    SELECT * FROM Party_H
+    WHERE valid_from_dts >= TIMESTAMP '2024-01-01 00:00:00+00:00'
+      AND valid_from_dts < TIMESTAMP '2024-02-01 00:00:00+00:00';
 
--- Convert to different timezone for display
-SELECT party_key,
-       valid_from_dts AT TIME ZONE 'America/New_York' AS valid_from_est,
-       valid_from_dts AT TIME ZONE 'Europe/London' AS valid_from_gmt
-FROM Party_H;
-```
+    -- Also correct: Database will convert to UTC
+    SELECT * FROM Party_H
+    WHERE valid_from_dts >= TIMESTAMP '2024-01-01 00:00:00-05:00'  -- EST
+      AND valid_from_dts < TIMESTAMP '2024-02-01 00:00:00-05:00';
 
-### 7.6 When TIMESTAMP (without timezone) Is Acceptable
+    -- Convert to different timezone for display
+    SELECT party_key,
+           valid_from_dts AT TIME ZONE 'America/New_York' AS valid_from_est,
+           valid_from_dts AT TIME ZONE 'Europe/London' AS valid_from_gmt
+    FROM Party_H;
+
+### 8.6 When TIMESTAMP (without timezone) Is Acceptable
 
 **Use TIMESTAMP without timezone only when:**
+
 - Data is purely local (single timezone, will never expand)
 - Regulatory requirement for specific timezone
 - Legacy system compatibility required
+
 
 **Document the timezone assumption explicitly**
 
 ---
 
-## 8. Data Quality Management
+## 9. Data Quality Management
 
-### 8.1 Advocated Quality Scoring Approach
+### 9.1 Advocated Quality Scoring Approach
 
 **Principle**: Agents need to assess data reliability before using it
 
-### 8.2 Quality Score Calculation
+### 9.2 Quality Score Calculation
 
 **Advocated**: 0.00-1.00 score based on validation rules
 
-```sql
--- Example: Party quality score
-quality_score = (
-    CASE WHEN legal_name IS NOT NULL THEN 0.20 ELSE 0 END +
-    CASE WHEN tax_identifier IS NOT NULL THEN 0.20 ELSE 0 END +
-    CASE WHEN email_address IS NOT NULL AND email_validated = 1 THEN 0.20 ELSE 0 END +
-    CASE WHEN phone_number IS NOT NULL AND phone_validated = 1 THEN 0.20 ELSE 0 END +
-    CASE WHEN address_complete = 1 THEN 0.20 ELSE 0 END
-)
-```
+    -- Example: Party quality score
+    quality_score = (
+        CASE WHEN legal_name IS NOT NULL THEN 0.20 ELSE 0 END +
+        CASE WHEN tax_identifier IS NOT NULL THEN 0.20 ELSE 0 END +
+        CASE WHEN email_address IS NOT NULL AND email_validated = 1 THEN 0.20 ELSE 0 END +
+        CASE WHEN phone_number IS NOT NULL AND phone_validated = 1 THEN 0.20 ELSE 0 END +
+        CASE WHEN address_complete = 1 THEN 0.20 ELSE 0 END
+    )
 
-### 8.3 Two Storage Approaches
+### 9.3 Two Storage Approaches
 
 #### Approach 1: Store Latest Score in Domain (Extended Column)
 
-```sql
-CREATE TABLE Party_H (
-    -- ... core columns ...
-    data_quality_score DECIMAL(3,2)
-        COMMENT 'Quality score 0.00-1.00 based on validation rules',
-    -- ...
-);
+    CREATE TABLE Party_H (
+        -- ... core columns ...
+        data_quality_score DECIMAL(3,2)
+            COMMENT 'Quality score 0.00-1.00 based on validation rules',
+        -- ...
+    );
 
--- Agent query
-SELECT party_key, legal_name, data_quality_score
-FROM Party_H
-WHERE is_current = 1
-  AND data_quality_score >= 0.75;  -- High quality only
-```
+    -- Agent query
+    SELECT party_key, legal_name, data_quality_score
+    FROM Party_H
+    WHERE is_current = 1
+      AND data_quality_score >= 0.75;  -- High quality only
 
-**Pros**: Simple, fast single-table queries
-**Cons**: Only latest score, no history, adds column overhead
+**Pros**: Simple, fast single-table queries **Cons**: Only latest score, no history, adds column overhead
 
 #### Approach 2: Store in Observability (Advocated)
 
-```sql
--- Store quality time-series in Observability
-INSERT INTO Observability.DataQuality_H (
-    entity_type, entity_id, evaluated_dts, quality_score,
-    rule_results_json
-) VALUES (
-    'PARTY', 1001, CURRENT_TIMESTAMP(6), 0.80,
-    JSON '{"rules": [
-        {"rule_id": "R01", "rule_name": "has_legal_name", "passed": true},
-        {"rule_id": "R02", "rule_name": "has_tax_id", "passed": true},
-        {"rule_id": "R03", "rule_name": "has_email", "passed": true},
-        {"rule_id": "R04", "rule_name": "has_phone", "passed": false}
-    ]}'
-);
+    -- Store quality time-series in Observability
+    INSERT INTO Observability.DataQuality_H (
+        entity_type, entity_id, evaluated_dts, quality_score,
+        rule_results_json
+    ) VALUES (
+        'PARTY', 1001, CURRENT_TIMESTAMP(6), 0.80,
+        JSON '{"rules": [
+            {"rule_id": "R01", "rule_name": "has_legal_name", "passed": true},
+            {"rule_id": "R02", "rule_name": "has_tax_id", "passed": true},
+            {"rule_id": "R03", "rule_name": "has_email", "passed": true},
+            {"rule_id": "R04", "rule_name": "has_phone", "passed": false}
+        ]}'
+    );
 
--- Agent query with quality filter
-SELECT p.party_key, p.legal_name, dq.quality_score
-FROM Party_H p
-INNER JOIN (
-    SELECT entity_id, quality_score,
-           ROW_NUMBER() OVER (PARTITION BY entity_id ORDER BY evaluated_dts DESC) AS rn
-    FROM Observability.DataQuality_H
-    WHERE entity_type = 'PARTY'
-) dq ON dq.entity_id = p.party_id AND dq.rn = 1
-WHERE p.is_current = 1
-  AND dq.quality_score >= 0.75;
-```
+    -- Agent query with quality filter
+    SELECT p.party_key, p.legal_name, dq.quality_score
+    FROM Party_H p
+    INNER JOIN (
+        SELECT entity_id, quality_score,
+               ROW_NUMBER() OVER (PARTITION BY entity_id ORDER BY evaluated_dts DESC) AS rn
+        FROM Observability.DataQuality_H
+        WHERE entity_type = 'PARTY'
+    ) dq ON dq.entity_id = p.party_id AND dq.rn = 1
+    WHERE p.is_current = 1
+      AND dq.quality_score >= 0.75;
 
-**Pros**: No Domain overhead, quality history, detailed rule results
-**Cons**: Requires join (mitigated by views)
+**Pros**: No Domain overhead, quality history, detailed rule results **Cons**: Requires join (mitigated by views)
 
-### 8.4 Advocated: Use Views for Agent Access
+### 9.4 Advocated: Use Views for Agent Access
 
-```sql
-CREATE VIEW Party_HighQuality AS
-SELECT p.party_id, p.party_key, p.legal_name,
-       dq.quality_score, dq.evaluated_dts,
-       dq.rule_results_json
-FROM Party_H p
-INNER JOIN (
-    SELECT entity_id, quality_score, evaluated_dts, rule_results_json,
-           ROW_NUMBER() OVER (PARTITION BY entity_id ORDER BY evaluated_dts DESC) AS rn
-    FROM Observability.DataQuality_H
-    WHERE entity_type = 'PARTY'
-) dq ON dq.entity_id = p.party_id AND dq.rn = 1
-WHERE p.is_current = 1
-  AND p.is_deleted = 0
-  AND dq.quality_score >= 0.75;
+    CREATE VIEW Party_HighQuality AS
+    SELECT p.party_id, p.party_key, p.legal_name,
+           dq.quality_score, dq.evaluated_dts,
+           dq.rule_results_json
+    FROM Party_H p
+    INNER JOIN (
+        SELECT entity_id, quality_score, evaluated_dts, rule_results_json,
+               ROW_NUMBER() OVER (PARTITION BY entity_id ORDER BY evaluated_dts DESC) AS rn
+        FROM Observability.DataQuality_H
+        WHERE entity_type = 'PARTY'
+    ) dq ON dq.entity_id = p.party_id AND dq.rn = 1
+    WHERE p.is_current = 1
+      AND p.is_deleted = 0
+      AND dq.quality_score >= 0.75;
 
--- Agent query (simple)
-SELECT * FROM Party_HighQuality WHERE party_key = 'CUST-12345';
-```
+    -- Agent query (simple)
+    SELECT * FROM Party_HighQuality WHERE party_key = 'CUST-12345';
 
-### 8.5 Quality Rule Framework
+### 9.5 Quality Rule Framework
 
 **Advocated**: Standard rule categories
 
 | Rule Category | Examples | Weight |
-|--------------|----------|--------|
+| --- | --- | --- |
 | **Completeness** | Required fields populated | 30% |
 | **Validity** | Format validation, range checks | 25% |
 | **Consistency** | Cross-field validation | 20% |
@@ -1061,113 +1169,104 @@ SELECT * FROM Party_HighQuality WHERE party_key = 'CUST-12345';
 
 ---
 
-## 9. Audit Trail Strategy
+## 10. Audit Trail Strategy
 
-### 9.1 Why Comprehensive Audit Trails
+### 10.1 Why Comprehensive Audit Trails
 
-**Regulatory**: GDPR, CCPA, SOX, HIPAA require audit trails
-**Explainability**: "Why did the model predict X?" requires historical context
-**Security**: Detect unauthorized changes
-**Debugging**: Trace data lineage and transformations
+**Regulatory**: GDPR, CCPA, SOX, HIPAA require audit trails **Explainability**: "Why did the model predict X?" requires historical context **Security**: Detect unauthorized changes **Debugging**: Trace data lineage and transformations
 
-### 9.2 Advocated Audit Approach
+### 10.2 Advocated Audit Approach
 
 **Store detailed audit in Observability.ChangeEvent_H**
 
-```sql
-CREATE TABLE Observability.ChangeEvent_H (
-    change_event_id    BIGINT NOT NULL,
-    entity_type         VARCHAR(50) NOT NULL,
-    entity_id          BIGINT NOT NULL,
-    change_type         VARCHAR(20) NOT NULL,  -- 'INSERT', 'UPDATE', 'DELETE'
-    
-    -- Who and when
-    changed_by          VARCHAR(100) NOT NULL,
-    changed_dts         TIMESTAMP(6) WITH TIME ZONE NOT NULL,
-    
-    -- What and why
-    change_reason       VARCHAR(500),
-    changed_columns     VARCHAR(2000),  -- JSON array: ["legal_name", "email"]
-    
-    -- Before and after
-    old_values_json     JSON,  -- {legal_name: "Jane Doe", email: "old@..."}
-    new_values_json     JSON,  -- {legal_name: "Jane Smith", email: "new@..."}
-    
-    -- Context
-    session_id          VARCHAR(100),
-    application_name VARCHAR(128),
-    ip_address          VARCHAR(50),
-    
-    PRIMARY INDEX (entity_id, changed_dts)
-)
-PARTITION BY RANGE_N(
-    changed_dts BETWEEN DATE '2020-01-01' AND DATE '2030-12-31' 
-    EACH INTERVAL '1' MONTH
-);
-```
+    CREATE TABLE Observability.ChangeEvent_H (
+        change_event_id    BIGINT NOT NULL,
+        entity_type         VARCHAR(50) NOT NULL,
+        entity_id          BIGINT NOT NULL,
+        change_type         VARCHAR(20) NOT NULL,  -- 'INSERT', 'UPDATE', 'DELETE'
+  
+        -- Who and when
+        changed_by          VARCHAR(100) NOT NULL,
+        changed_dts         TIMESTAMP(6) WITH TIME ZONE NOT NULL,
+  
+        -- What and why
+        change_reason       VARCHAR(500),
+        changed_columns     VARCHAR(2000),  -- JSON array: ["legal_name", "email"]
+  
+        -- Before and after
+        old_values_json     JSON,  -- {legal_name: "Jane Doe", email: "old@..."}
+        new_values_json     JSON,  -- {legal_name: "Jane Smith", email: "new@..."}
+  
+        -- Context
+        session_id          VARCHAR(100),
+        application_name VARCHAR(128),
+        ip_address          VARCHAR(50),
+  
+        PRIMARY INDEX (entity_id, changed_dts)
+    )
+    PARTITION BY RANGE_N(
+        changed_dts BETWEEN DATE '2020-01-01' AND DATE '2030-12-31'
+        EACH INTERVAL '1' MONTH
+    );
 
-### 9.3 Capturing Change Events
+### 10.3 Capturing Change Events
 
-```sql
--- Example: Capture UPDATE event
-INSERT INTO Observability.ChangeEvent_H (
-    change_event_id, entity_type, entity_id, change_type,
-    changed_by, changed_dts, change_reason,
-    changed_columns, old_values_json, new_values_json
-)
-SELECT 
-    change_event_seq.NEXTVAL,
-    'PARTY',
-    1001,
-    'UPDATE',
-    'data_steward@company.com',
-    CURRENT_TIMESTAMP(6),
-    'Customer name change due to marriage',
-    JSON '["legal_name"]',
-    JSON '{"legal_name": "Jane Doe"}',
-    JSON '{"legal_name": "Jane Smith"}';
-```
+    -- Example: Capture UPDATE event
+    INSERT INTO Observability.ChangeEvent_H (
+        change_event_id, entity_type, entity_id, change_type,
+        changed_by, changed_dts, change_reason,
+        changed_columns, old_values_json, new_values_json
+    )
+    SELECT
+        change_event_seq.NEXTVAL,
+        'PARTY',
+        1001,
+        'UPDATE',
+        'data_steward@company.com',
+        CURRENT_TIMESTAMP(6),
+        'Customer name change due to marriage',
+        JSON '["legal_name"]',
+        JSON '{"legal_name": "Jane Doe"}',
+        JSON '{"legal_name": "Jane Smith"}';
 
-### 9.4 Audit Trail Queries
+### 10.4 Audit Trail Queries
 
-```sql
--- Complete audit history for an entity
-SELECT 
-    changed_dts,
-    changed_by,
-    change_type,
-    change_reason,
-    changed_columns,
-    old_values_json,
-    new_values_json
-FROM Observability.ChangeEvent_H
-WHERE entity_type = 'PARTY'
-  AND entity_id = 1001
-ORDER BY changed_dts;
+    -- Complete audit history for an entity
+    SELECT
+        changed_dts,
+        changed_by,
+        change_type,
+        change_reason,
+        changed_columns,
+        old_values_json,
+        new_values_json
+    FROM Observability.ChangeEvent_H
+    WHERE entity_type = 'PARTY'
+      AND entity_id = 1001
+    ORDER BY changed_dts;
 
--- Who deleted this record and why?
-SELECT changed_by, changed_dts, change_reason
-FROM Observability.ChangeEvent_H
-WHERE entity_type = 'PARTY'
-  AND entity_id = 1001
-  AND change_type = 'DELETE'
-ORDER BY changed_dts DESC
-LIMIT 1;
+    -- Who deleted this record and why?
+    SELECT changed_by, changed_dts, change_reason
+    FROM Observability.ChangeEvent_H
+    WHERE entity_type = 'PARTY'
+      AND entity_id = 1001
+      AND change_type = 'DELETE'
+    ORDER BY changed_dts DESC
+    LIMIT 1;
 
--- All changes by a specific user
-SELECT entity_type, entity_id, change_type, changed_dts
-FROM Observability.ChangeEvent_H
-WHERE changed_by = 'data_steward@company.com'
-  AND changed_dts >= CURRENT_DATE - 30
-ORDER BY changed_dts DESC;
-```
+    -- All changes by a specific user
+    SELECT entity_type, entity_id, change_type, changed_dts
+    FROM Observability.ChangeEvent_H
+    WHERE changed_by = 'data_steward@company.com'
+      AND changed_dts >= CURRENT_DATE - 30
+    ORDER BY changed_dts DESC;
 
-### 9.5 Retention Policy
+### 10.5 Retention Policy
 
 **Advocated retention periods:**
 
 | Audit Data Type | Retention | Rationale |
-|----------------|-----------|-----------|
+| --- | --- | --- |
 | **Recent changes** | 2 years online | Active investigations |
 | **Historical changes** | 7 years archived | Regulatory compliance |
 | **Deletion records** | 10 years archived | GDPR accountability |
@@ -1175,268 +1274,264 @@ ORDER BY changed_dts DESC;
 
 ---
 
-## 10. Platform Implementation Guidance: Teradata
+## 11. Platform Implementation Guidance: Teradata
 
-> **Platform Profile — Teradata**
-> This section is the reference Platform Profile for Teradata implementations of the AI-Native Data Product standard. The structural requirements in the module design standards are platform-agnostic; the guidance below is Teradata-specific. Teams implementing on other platforms should produce an equivalent Platform Profile for their target, covering the same topics: physical key strategy, partitioning, indexing, statistics collection, compression, and query optimisation.
+> **Platform Profile — Teradata** This section is the reference Platform Profile for Teradata implementations of the AI-Native Data Product standard. The structural requirements in the module design standards are platform-agnostic; the guidance below is Teradata-specific. Teams implementing on other platforms should produce an equivalent Platform Profile for their target, covering the same topics: physical key strategy, partitioning, indexing, statistics collection, compression, and query optimisation.
 
-### 10.1 Why Physical Design Matters for AI Workloads
+### 11.1 Why Physical Design Matters for AI Workloads
 
 AI-Native workloads have different access patterns than traditional BI:
+
 - Point-in-time feature computation (temporal queries)
 - High-volume batch processing (ML training)
 - Low-latency single-row lookups (agent queries)
 - Cross-module joins (enriched context)
 
+
 **Advocated approach**: Design physical structures for these specific patterns.
 
-### 10.2 Primary Index Selection
+### 11.2 Primary Index Selection
 
 **Primary Index (PI) is the most critical physical design decision in Teradata.**
 
 #### Advocated PI Selection by Entity Type
 
 | Entity Type | Advocated PI | Rationale |
-|-------------|--------------|-----------|
+| --- | --- | --- |
 | **Core entities** | Surrogate key (UPI) | Even distribution, simple joins |
 | **High-volume entities** | Consider natural key (NUPI) | If frequently queried by business ID |
 | **Reference data** | Code (UPI) | Code lookups most common |
 | **Relationship tables** | Composite FK (NUPI) | Co-locate with parent entity |
 | **Time-series entities** | Composite: entity + time (NUPI) | Partition elimination benefits |
 
+
 #### PI Selection Decision Tree
 
-```
-START: What is primary access pattern?
-├─ Single-row lookup by surrogate key?
-│  └─ Use surrogate key UPI ✅
-├─ Single-row lookup by natural key?
-│  └─ Use natural key UPI ✅
-├─ Range queries on time + entity?
-│  └─ Use composite (entity_id, time_column) NUPI ✅
-├─ Frequent joins to parent entity?
-│  └─ Use parent FK for co-location NUPI ✅
-└─ Mixed patterns?
-   └─ Use surrogate key UPI + secondary indexes ✅
-```
+    START: What is primary access pattern?
+    ├─ Single-row lookup by surrogate key?
+    │  └─ Use surrogate key UPI ✅
+    ├─ Single-row lookup by natural key?
+    │  └─ Use natural key UPI ✅
+    ├─ Range queries on time + entity?
+    │  └─ Use composite (entity_id, time_column) NUPI ✅
+    ├─ Frequent joins to parent entity?
+    │  └─ Use parent FK for co-location NUPI ✅
+    └─ Mixed patterns?
+       └─ Use surrogate key UPI + secondary indexes ✅
 
 #### PI Examples
 
-```sql
--- Pattern 1: Surrogate key UPI (most common)
-CREATE TABLE Party_H (
-    party_id BIGINT NOT NULL,
-    -- ... columns ...
-    PRIMARY INDEX (party_id)
-)
-UNIQUE PRIMARY INDEX (party_id, valid_from_dts, transaction_from_dts);
+    -- Pattern 1: Surrogate key UPI (most common)
+    CREATE TABLE Party_H (
+        party_id BIGINT NOT NULL,
+        -- ... columns ...
+        PRIMARY INDEX (party_id)
+    )
+    UNIQUE PRIMARY INDEX (party_id, valid_from_dts, transaction_from_dts);
 
--- Pattern 2: Natural key UPI (frequent business ID queries)
-CREATE TABLE Product_H (
-    product_id BIGINT NOT NULL,
-    product_key VARCHAR(50) NOT NULL,
-    -- ... columns ...
-    PRIMARY INDEX (product_key)  -- If most queries filter on product_key
-)
-UNIQUE PRIMARY INDEX (product_id, valid_from_dts, transaction_from_dts);
+    -- Pattern 2: Natural key UPI (frequent business ID queries)
+    CREATE TABLE Product_H (
+        product_id BIGINT NOT NULL,
+        product_key VARCHAR(50) NOT NULL,
+        -- ... columns ...
+        PRIMARY INDEX (product_key)  -- If most queries filter on product_key
+    )
+    UNIQUE PRIMARY INDEX (product_id, valid_from_dts, transaction_from_dts);
 
--- Pattern 3: Composite NUPI (relationship table, co-located)
-CREATE TABLE PartyProduct_H (
-    party_product_id BIGINT NOT NULL,
-    party_id BIGINT NOT NULL,
-    product_id BIGINT NOT NULL,
-    -- ... columns ...
-    PRIMARY INDEX (party_id, product_id)  -- Co-locate with Party
-)
-UNIQUE PRIMARY INDEX (party_product_id, valid_from_dts, transaction_from_dts);
+    -- Pattern 3: Composite NUPI (relationship table, co-located)
+    CREATE TABLE PartyProduct_H (
+        party_product_id BIGINT NOT NULL,
+        party_id BIGINT NOT NULL,
+        product_id BIGINT NOT NULL,
+        -- ... columns ...
+        PRIMARY INDEX (party_id, product_id)  -- Co-locate with Party
+    )
+    UNIQUE PRIMARY INDEX (party_product_id, valid_from_dts, transaction_from_dts);
 
--- Pattern 4: Time-based composite (time-series data)
-CREATE TABLE Transaction_H (
-    transaction_id BIGINT NOT NULL,
-    party_id BIGINT NOT NULL,
-    transaction_dts TIMESTAMP(6) WITH TIME ZONE NOT NULL,
-    -- ... columns ...
-    PRIMARY INDEX (party_id, transaction_dts)  -- Time-series queries
-)
-UNIQUE PRIMARY INDEX (transaction_id, valid_from_dts, transaction_from_dts)
-PARTITION BY RANGE_N(
-    transaction_dts BETWEEN DATE '2020-01-01' AND DATE '2030-12-31' 
-    EACH INTERVAL '1' MONTH
-);
-```
+    -- Pattern 4: Time-based composite (time-series data)
+    CREATE TABLE Transaction_H (
+        transaction_id BIGINT NOT NULL,
+        party_id BIGINT NOT NULL,
+        transaction_dts TIMESTAMP(6) WITH TIME ZONE NOT NULL,
+        -- ... columns ...
+        PRIMARY INDEX (party_id, transaction_dts)  -- Time-series queries
+    )
+    UNIQUE PRIMARY INDEX (transaction_id, valid_from_dts, transaction_from_dts)
+    PARTITION BY RANGE_N(
+        transaction_dts BETWEEN DATE '2020-01-01' AND DATE '2030-12-31'
+        EACH INTERVAL '1' MONTH
+    );
 
-### 10.3 Partitioning Strategy
+### 11.3 Partitioning Strategy
 
 **Advocate partitioning for:**
+
 - Tables > 100M rows
 - Time-series access patterns
 - Need for partition elimination
 
+
 #### Advocated Partitioning Approaches
 
 | Partitioning Dimension | When to Use | Example |
-|------------------------|-------------|---------|
+| --- | --- | --- |
 | **Transaction time** | Most common - queries filter on load/update date | `transaction_from_dts` |
 | **Valid time** | Business queries filter on effective date | `valid_from_dts` |
 | **Date attribute** | Event data with natural dates | `transaction_date`, `order_date` |
 | **Multi-level** | Combine time + status/type | Time + is_deleted |
 
+
 #### Partitioning Examples
 
-```sql
--- Pattern 1: Monthly partitioning (most common)
-PARTITION BY RANGE_N(
-    transaction_from_dts BETWEEN DATE '2020-01-01' 
-                           AND DATE '2030-12-31' 
-                           EACH INTERVAL '1' MONTH
-);
+    -- Pattern 1: Monthly partitioning (most common)
+    PARTITION BY RANGE_N(
+        transaction_from_dts BETWEEN DATE '2020-01-01'
+                               AND DATE '2030-12-31'
+                               EACH INTERVAL '1' MONTH
+    );
 
--- Pattern 2: Quarterly partitioning (moderate volume)
-PARTITION BY RANGE_N(
-    transaction_from_dts BETWEEN DATE '2020-01-01' 
-                           AND DATE '2030-12-31' 
-                           EACH INTERVAL '3' MONTH
-);
+    -- Pattern 2: Quarterly partitioning (moderate volume)
+    PARTITION BY RANGE_N(
+        transaction_from_dts BETWEEN DATE '2020-01-01'
+                               AND DATE '2030-12-31'
+                               EACH INTERVAL '3' MONTH
+    );
 
--- Pattern 3: Daily partitioning (very high volume)
-PARTITION BY RANGE_N(
-    transaction_dts BETWEEN DATE '2024-01-01' 
-                      AND DATE '2025-12-31' 
-                      EACH INTERVAL '1' DAY
-);
+    -- Pattern 3: Daily partitioning (very high volume)
+    PARTITION BY RANGE_N(
+        transaction_dts BETWEEN DATE '2024-01-01'
+                          AND DATE '2025-12-31'
+                          EACH INTERVAL '1' DAY
+    );
 
--- Pattern 4: Multi-level (time + status)
-PARTITION BY (
-    RANGE_N(
-        valid_from_dts BETWEEN DATE '2020-01-01' 
-                        AND DATE '2030-12-31' 
-                        EACH INTERVAL '1' YEAR
-    ),
-    CASE_N(
-        is_deleted = 0,   -- Partition 1: Active
-        is_deleted = 1,   -- Partition 2: Deleted
-        UNKNOWN           -- Partition 3: NULL
-    )
-);
-```
+    -- Pattern 4: Multi-level (time + status)
+    PARTITION BY (
+        RANGE_N(
+            valid_from_dts BETWEEN DATE '2020-01-01'
+                            AND DATE '2030-12-31'
+                            EACH INTERVAL '1' YEAR
+        ),
+        CASE_N(
+            is_deleted = 0,   -- Partition 1: Active
+            is_deleted = 1,   -- Partition 2: Deleted
+            UNKNOWN           -- Partition 3: NULL
+        )
+    );
 
 #### Partitioning Decision Tree
 
-```
-START: Table size?
-├─ < 100M rows → No partitioning needed ⚠️
-└─ > 100M rows → What's primary query pattern?
-   ├─ Time range queries common?
-   │  └─ Partition by time column ✅
-   ├─ Status/type filtering common?
-   │  └─ Consider multi-level partitioning ✅
-   └─ Full table scans anyway?
-      └─ Partitioning won't help ⚠️
-```
+    START: Table size?
+    ├─ < 100M rows → No partitioning needed ⚠️
+    └─ > 100M rows → What's primary query pattern?
+       ├─ Time range queries common?
+       │  └─ Partition by time column ✅
+       ├─ Status/type filtering common?
+       │  └─ Consider multi-level partitioning ✅
+       └─ Full table scans anyway?
+          └─ Partitioning won't help ⚠️
 
-### 10.4 Secondary Index Strategy
+### 11.4 Secondary Index Strategy
 
 **Advocate selective use of secondary indexes.**
 
 #### When to Create Secondary Indexes
 
 | Create SI When: | Avoid SI When: |
-|-----------------|----------------|
+| --- | --- |
 | ✅ Critical query doesn't use PI | ❌ Query is rare/ad-hoc |
 | ✅ Query performance unacceptable | ❌ PI already covers query |
 | ✅ Insert volume is moderate | ❌ High insert/update volume |
 | ✅ Query is frequent | ❌ Query is already fast |
 
+
 #### Advocated Secondary Index Patterns
 
-```sql
--- Pattern 1: Natural key index (when PI is surrogate key)
-CREATE UNIQUE INDEX idx_party_natural_key
-ON Party_H (party_key)
-WHERE is_current = 1 AND is_deleted = 0;
+    -- Pattern 1: Natural key index (when PI is surrogate key)
+    CREATE UNIQUE INDEX idx_party_natural_key
+    ON Party_H (party_key)
+    WHERE is_current = 1 AND is_deleted = 0;
 
--- Pattern 2: Foreign key index (for join optimization)
-CREATE INDEX idx_partyproduct_product
-ON PartyProduct_H (product_id)
-WHERE is_current = 1 AND is_deleted = 0;
+    -- Pattern 2: Foreign key index (for join optimization)
+    CREATE INDEX idx_partyproduct_product
+    ON PartyProduct_H (product_id)
+    WHERE is_current = 1 AND is_deleted = 0;
 
--- Pattern 3: Composite index (multi-column filters)
-CREATE INDEX idx_product_category_type
-ON Product_H (product_category, product_type_code)
-WHERE is_current = 1 AND is_deleted = 0;
+    -- Pattern 3: Composite index (multi-column filters)
+    CREATE INDEX idx_product_category_type
+    ON Product_H (product_category, product_type_code)
+    WHERE is_current = 1 AND is_deleted = 0;
 
--- Pattern 4: Covering index (include frequently selected columns)
-CREATE INDEX idx_party_lookup (party_key, legal_name, status_code)
-ON Party_H (party_key)
-WHERE is_current = 1 AND is_deleted = 0;
-```
+    -- Pattern 4: Covering index (include frequently selected columns)
+    CREATE INDEX idx_party_lookup (party_key, legal_name, status_code)
+    ON Party_H (party_key)
+    WHERE is_current = 1 AND is_deleted = 0;
 
-### 10.5 Join Index Strategy
+### 11.5 Join Index Strategy
 
 **Advocate join indexes for:**
+
 - Expensive joins used frequently
 - Pre-computed aggregations
 - Materialized views
 
+
 #### Join Index Patterns
 
-```sql
--- Pattern 1: Current version materialized view
-CREATE JOIN INDEX jidx_party_current AS
-SELECT 
-    party_id,
-    party_key,
-    legal_name,
-    party_type_code,
-    status_code
-FROM Party_H
-WHERE is_current = 1
-  AND is_deleted = 0
-  AND transaction_to_dts = TIMESTAMP '9999-12-31 23:59:59.999999+00:00'
-PRIMARY INDEX (party_id);
+    -- Pattern 1: Current version materialized view
+    CREATE JOIN INDEX jidx_party_current AS
+    SELECT
+        party_id,
+        party_key,
+        legal_name,
+        party_type_code,
+        status_code
+    FROM Party_H
+    WHERE is_current = 1
+      AND is_deleted = 0
+      AND transaction_to_dts = TIMESTAMP '9999-12-31 23:59:59.999999+00:00'
+    PRIMARY INDEX (party_id);
 
--- Pattern 2: Denormalized join (frequent join pattern)
-CREATE JOIN INDEX jidx_party_product_denorm AS
-SELECT 
-    p.party_id,
-    p.party_key,
-    p.legal_name,
-    pp.product_id,
-    pr.product_key,
-    pr.product_name
-FROM Party_H p
-INNER JOIN PartyProduct_H pp 
-    ON p.party_id = pp.party_id
-INNER JOIN Product_H pr 
-    ON pp.product_id = pr.product_id
-WHERE p.is_current = 1 AND p.is_deleted = 0
-  AND pp.is_current = 1 AND pp.is_deleted = 0
-  AND pr.is_current = 1 AND pr.is_deleted = 0
-PRIMARY INDEX (party_id);
+    -- Pattern 2: Denormalized join (frequent join pattern)
+    CREATE JOIN INDEX jidx_party_product_denorm AS
+    SELECT
+        p.party_id,
+        p.party_key,
+        p.legal_name,
+        pp.product_id,
+        pr.product_key,
+        pr.product_name
+    FROM Party_H p
+    INNER JOIN PartyProduct_H pp
+        ON p.party_id = pp.party_id
+    INNER JOIN Product_H pr
+        ON pp.product_id = pr.product_id
+    WHERE p.is_current = 1 AND p.is_deleted = 0
+      AND pp.is_current = 1 AND pp.is_deleted = 0
+      AND pr.is_current = 1 AND pr.is_deleted = 0
+    PRIMARY INDEX (party_id);
 
--- Pattern 3: Pre-computed aggregation
-CREATE JOIN INDEX jidx_party_metrics AS
-SELECT 
-    party_id,
-    COUNT(*) AS product_cnt,
-    SUM(balance_amt) AS total_balance_amt,
-    MAX(last_transaction_dts) AS last_activity_dts
-FROM Party_H p
-INNER JOIN PartyProduct_H pp ON p.party_id = pp.party_id
-WHERE p.is_current = 1 AND p.is_deleted = 0
-  AND pp.is_current = 1 AND pp.is_deleted = 0
-GROUP BY party_id
-PRIMARY INDEX (party_id);
-```
+    -- Pattern 3: Pre-computed aggregation
+    CREATE JOIN INDEX jidx_party_metrics AS
+    SELECT
+        party_id,
+        COUNT(*) AS product_cnt,
+        SUM(balance_amt) AS total_balance_amt,
+        MAX(last_transaction_dts) AS last_activity_dts
+    FROM Party_H p
+    INNER JOIN PartyProduct_H pp ON p.party_id = pp.party_id
+    WHERE p.is_current = 1 AND p.is_deleted = 0
+      AND pp.is_current = 1 AND pp.is_deleted = 0
+    GROUP BY party_id
+    PRIMARY INDEX (party_id);
 
-### 10.6 Compression Strategy
+### 11.6 Compression Strategy
 
 **Advocate compression for large text columns.**
 
 #### Compression Candidates
 
 | Column Type | Compress? | Method |
-|-------------|-----------|--------|
+| --- | --- | --- |
 | **Large text (>500 chars)** | ✅ Yes | AUTO COMPRESS |
 | **JSON columns** | ✅ Yes | AUTO COMPRESS or ZLIB |
 | **Sparse columns** | ✅ Yes | AUTO COMPRESS |
@@ -1444,67 +1539,65 @@ PRIMARY INDEX (party_id);
 | **Numeric columns** | ❌ No | Minimal benefit |
 | **Frequently updated** | ⚠️ Caution | Recompression cost |
 
+
 #### Compression Examples
 
-```sql
--- Pattern 1: AUTO COMPRESS (recommended)
-CREATE TABLE Party_H (
-    party_id BIGINT NOT NULL,
-    -- ... other columns ...
-    notes_txt VARCHAR(5000),
-    address_text VARCHAR(500)
-)
-WITH COLUMN_PARTITION = (
-    AUTO COMPRESS (notes_txt, address_text)
-);
+    -- Pattern 1: AUTO COMPRESS (recommended)
+    CREATE TABLE Party_H (
+        party_id BIGINT NOT NULL,
+        -- ... other columns ...
+        notes_txt VARCHAR(5000),
+        address_text VARCHAR(500)
+    )
+    WITH COLUMN_PARTITION = (
+        AUTO COMPRESS (notes_txt, address_text)
+    );
 
--- Pattern 2: Specific algorithm for very large text
-CREATE TABLE Document_H (
-    document_id BIGINT NOT NULL,
-    document_content CLOB
-)
-WITH COLUMN_PARTITION = (
-    COLUMN (document_content) COMPRESS USING ZLIBHIGH
-);
-```
+    -- Pattern 2: Specific algorithm for very large text
+    CREATE TABLE Document_H (
+        document_id BIGINT NOT NULL,
+        document_content CLOB
+    )
+    WITH COLUMN_PARTITION = (
+        COLUMN (document_content) COMPRESS USING ZLIBHIGH
+    );
 
-### 10.7 Statistics Collection
+### 11.7 Statistics Collection
 
 **Advocate automated statistics collection.**
 
 #### Statistics Strategy
 
-```sql
--- Collect stats on critical columns
-COLLECT STATISTICS 
-COLUMN (party_id),
-COLUMN (party_key),
-COLUMN (party_type_code),
-COLUMN (is_current),
-COLUMN (is_deleted),
-COLUMN (valid_from_dts),
-COLUMN (transaction_from_dts)
-ON Party_H;
+    -- Collect stats on critical columns
+    COLLECT STATISTICS
+    COLUMN (party_id),
+    COLUMN (party_key),
+    COLUMN (party_type_code),
+    COLUMN (is_current),
+    COLUMN (is_deleted),
+    COLUMN (valid_from_dts),
+    COLUMN (transaction_from_dts)
+    ON Party_H;
 
--- Collect stats on composite filters
-COLLECT STATISTICS 
-COLUMN (party_type_code, is_current, is_deleted)
-ON Party_H;
+    -- Collect stats on composite filters
+    COLLECT STATISTICS
+    COLUMN (party_type_code, is_current, is_deleted)
+    ON Party_H;
 
--- For large tables, use sampling
-COLLECT STATISTICS ON Party_H USING SAMPLE 10 PERCENT;
-```
+    -- For large tables, use sampling
+    COLLECT STATISTICS ON Party_H USING SAMPLE 10 PERCENT;
 
 #### Advocated Collection Schedule
 
 | Table Size | Frequency | Method |
-|------------|-----------|--------|
+| --- | --- | --- |
 | **< 1M rows** | After major loads | Full scan |
 | **1M - 100M rows** | Daily | 10% sample |
 | **> 100M rows** | Weekly | 5% sample |
 | **Reference tables** | After changes only | Full scan |
 
-### 10.8 Physical Design Checklist
+
+### 11.8 Physical Design Checklist
 
 **Before implementation:**
 
@@ -1520,75 +1613,68 @@ COLLECT STATISTICS ON Party_H USING SAMPLE 10 PERCENT;
 
 ---
 
-## 11. Implementation Decision Trees
+## 12. Implementation Decision Trees
 
-### 10.1 Temporal Pattern Decision
+### 12.1 Temporal Pattern Decision
 
-```
-START: Do you need point-in-time correctness for ML features?
-├─ YES → Are late-arriving facts common?
-│  ├─ YES → Use BI-TEMPORAL ✅ (Advocated)
-│  └─ NO → Are corrections needed?
-│     ├─ YES → Use BI-TEMPORAL ✅
-│     └─ NO → Type 2 SCD acceptable ⚠️
-└─ NO → Is complete audit trail required?
-   ├─ YES → Use BI-TEMPORAL ✅
-   └─ NO → Type 2 SCD acceptable ⚠️
-```
+    START: Do you need point-in-time correctness for ML features?
+    ├─ YES → Are late-arriving facts common?
+    │  ├─ YES → Use BI-TEMPORAL ✅ (Advocated)
+    │  └─ NO → Are corrections needed?
+    │     ├─ YES → Use BI-TEMPORAL ✅
+    │     └─ NO → Type 2 SCD acceptable ⚠️
+    └─ NO → Is complete audit trail required?
+       ├─ YES → Use BI-TEMPORAL ✅
+       └─ NO → Type 2 SCD acceptable ⚠️
 
-### 10.2 Column Strategy Decision
+### 12.2 Column Strategy Decision
 
-```
-START: What is table volume?
-├─ < 10M rows → Core + Extended OK ⚠️
-├─ 10M - 100M rows → Core + FK Refs ✅ (Advocated)
-└─ > 100M rows → Core Only + Views ✅ (Advocated)
-    │
-    ├─ Need fast audit access?
-    │  ├─ YES → Add change_event_id FK
-    │  └─ NO → Join by entity_id (no FK)
-    │
-    ├─ Need fast lineage access?
-    │  ├─ YES → Add lineage_id FK
-    │  └─ NO → Join by entity_id (no FK)
-    │
-    └─ Need fast quality access?
-       ├─ YES → Add quality_id FK
-       └─ NO → Join by entity_id (no FK)
-```
+    START: What is table volume?
+    ├─ < 10M rows → Core + Extended OK ⚠️
+    ├─ 10M - 100M rows → Core + FK Refs ✅ (Advocated)
+    └─ > 100M rows → Core Only + Views ✅ (Advocated)
+        │
+        ├─ Need fast audit access?
+        │  ├─ YES → Add change_event_id FK
+        │  └─ NO → Join by entity_id (no FK)
+        │
+        ├─ Need fast lineage access?
+        │  ├─ YES → Add lineage_id FK
+        │  └─ NO → Join by entity_id (no FK)
+        │
+        └─ Need fast quality access?
+           ├─ YES → Add quality_id FK
+           └─ NO → Join by entity_id (no FK)
 
-### 10.3 Delete Strategy Decision
+### 12.3 Delete Strategy Decision
 
-```
-START: Is regulatory audit trail required?
-├─ YES → SOFT DELETE ✅ (Advocated)
-└─ NO → Do ML features depend on deletion status?
-   ├─ YES → SOFT DELETE ✅
-   └─ NO → Need analytics on deletion patterns?
-      ├─ YES → SOFT DELETE ✅
-      └─ NO → Is storage extremely constrained?
-         ├─ YES → Hard delete acceptable ⚠️
-         └─ NO → SOFT DELETE ✅ (safest default)
-```
+    START: Is regulatory audit trail required?
+    ├─ YES → SOFT DELETE ✅ (Advocated)
+    └─ NO → Do ML features depend on deletion status?
+       ├─ YES → SOFT DELETE ✅
+       └─ NO → Need analytics on deletion patterns?
+          ├─ YES → SOFT DELETE ✅
+          └─ NO → Is storage extremely constrained?
+             ├─ YES → Hard delete acceptable ⚠️
+             └─ NO → SOFT DELETE ✅ (safest default)
 
-### 10.4 Quality Storage Decision
+### 12.4 Quality Storage Decision
 
-```
-START: What is table volume?
-├─ < 10M rows → Either approach OK
-│  ├─ Simple implementation priority? → Store in Domain ⚠️
-│  └─ Quality history needed? → Store in Observability ✅
-└─ > 10M rows → Store in Observability ✅ (Advocated)
-    │
-    └─ Create views for agent access? → YES ✅ (Always)
-```
+    START: What is table volume?
+    ├─ < 10M rows → Either approach OK
+    │  ├─ Simple implementation priority? → Store in Domain ⚠️
+    │  └─ Quality history needed? → Store in Observability ✅
+    └─ > 10M rows → Store in Observability ✅ (Advocated)
+        │
+        └─ Create views for agent access? → YES ✅ (Always)
 
 ---
 
 ## Document Change Log
 
 | Version | Date | Changes | Author |
-|---------|------|---------|--------|
+| --- | --- | --- | --- |
+| 1.6 | 2026-05-08 | Added Section 6 (Access Layer). Defers placement, naming, separation, and access to the Object Placement Standard (interface specification + platform implementations). Establishes the principle of reading through views without prescribing where tables and views are placed. Lists builder/agent behaviour: locate a conforming Object Placement Standard before generating any object; halt and ask if absent. Sections 6–11 renumbered to 7–12. Subsection numbers within the renumbered Implementation Decision Trees corrected from 11.1–11.4 to 12.1–12.4. | Paul Dancer, Worldwide Field Tech, Teradata |
 | 1.5 | 2026-04-15 | Established platform neutrality. Renamed Section 10 from "Physical Design for Teradata" to "Platform Implementation Guidance: Teradata" and added a Platform Profile preamble making explicit that this section is Teradata-specific and that other platforms should produce equivalent profiles. Section 10 content unchanged. | Nathan Green, Worldwide Data Architecture Team, Teradata |
 | 1.4 | 2026-04-10 | Section 4 (Surrogate Key Strategy) rewritten to address surrogate key instability in SCD Type 2 tables (issue #7). Added Section 4.2 explaining why IDENTITY on _H tables fails; Section 4.3 documenting the recommended Keymap pattern (with flexibility note that organisations should use their own standard if one exists); Section 4.4 (Reference and Lookup Table Exemption) clarifying that reference/lookup tables and detail entities not FK-referenced may use IDENTITY directly; Section 4.5 providing a decision tree with three allocation options; Section 4.6 (natural keys, renamed from old 4.4). Removed old Sections 4.2-4.3 which incorrectly advocated IDENTITY on _H tables. | Nathan Green, Worldwide Data Architecture Team, Teradata |
 | 1.3 | 2026-03-20 | Completed swap of id and key to be consistent throughout design standards | Nathan Green, Worldwide Data Architecture Team, Teradata |

--- a/platform-standards/Object_Placement_Standard_Spec.md
+++ b/platform-standards/Object_Placement_Standard_Spec.md
@@ -1,0 +1,306 @@
+# Object Placement Standard — Interface Specification
+
+**Version:** 1.0  
+**Status:** Normative  
+**Scope:** Any relational or cloud data platform  
+**Maintained by:** Paul Dancer — Ecosystem Architect - Teradata Worldwide Field Tech
+
+---
+
+## Purpose
+
+This document defines the interface that any **Object Placement Standard** must satisfy for use with the AI-Native Data Product framework.
+
+An AI-Native Data Product agent **must not** make assumptions about how an organisation structures its data containers. It **must** read a conforming implementation of this spec before generating any DDL, object placement decision, or access control statement.
+
+This spec is **platform-agnostic**. It uses abstract terms (container, namespace, access principal) that map to platform-specific constructs in each implementation. It does not prescribe naming conventions, SQL dialects, or organisational structure — it only prescribes what must be declared.
+
+---
+
+## Terminology
+
+| Term | Meaning |
+|---|---|
+| **Container** | The smallest named unit of object ownership on the platform. Maps to: Teradata DATABASE, Snowflake SCHEMA, BigQuery DATASET, Databricks SCHEMA, etc. |
+| **Namespace** | A hierarchical grouping of containers. May be implicit (Teradata) or explicit (Databricks catalog.schema). |
+| **Object** | A first-class data artefact: table, view, procedure, macro, function, index. |
+| **Object type** | The kind of object. Implementations must declare which types they recognise and how they abbreviate them. |
+| **Parent container** | A container that allocates space or organises child containers but holds no objects itself. Not all platforms have this concept. |
+| **Child container** | A container that holds objects. On platforms with no parent concept, all containers are child containers. |
+| **Access principal** | An identity that can be granted access rights. Maps to: Teradata ROLE or USER, Snowflake ROLE, BigQuery IAM principal, etc. |
+| **Separation policy** | The rule governing whether different object types are co-located in the same container or separated into distinct containers. |
+| **Structural container** | A container that exists solely to organise administrative scope, space allocation, or namespace grouping. It holds no data objects and no child containers that directly hold objects. Structural containers sit above the standard parent/child hierarchy. Not all platforms have this concept — implementations must declare whether they use it. |
+| **Derivation function** | The deterministic algorithm that computes the correct target container name for a given object, given a set of input parameters. |
+| **Validation procedure** | The platform-specific mechanism that confirms objects have been placed in the correct containers after generation. |
+| **Implied grant** | An access permission that is not granted to an end-user principal directly, but is required for the separation architecture to function correctly — for example, a cross-container permission that allows a view in one container to reference objects in another. |
+
+---
+
+## Agent Consumption Instructions
+
+When generating any object for a data product:
+
+1. **Locate** a conforming implementation of this spec using the priority order below.
+2. **Read all required sections** before generating any DDL statement, access grant, or access revocation.
+3. **For each object**, call the Derivation Function with the object's type and context to determine its target container.
+4. **Generate** the object in that container only. Never place objects in a structural container, a parent container, or in a container designated for a different object type.
+5. **Provision implied grants** — if the implementation declares implied grants required by the separation architecture, provision them as part of the standard sequence, not as an afterthought.
+6. **Run** the Validation Procedure after generation. If it fails, halt and report — do not proceed with dependent objects.
+7. **Never assume** co-location of object types. Never default to a flat structure. If uncertain, ask.
+
+**Priority order for locating an implementation:**
+
+1. An explicit file path provided in the current conversation or project instructions
+2. `/mnt/skills/user/object-placement/SKILL.md`
+3. A file matching `Object_Placement_Standard*.md` in the project context
+4. **If none of the above exist:** STOP. Do not proceed. Ask the user:
+
+   > *"Before I generate any objects, I need your Object Placement Standard. Where should tables, views, and other object types be placed? Are they separated into distinct containers, or co-located? What is the naming convention for those containers?"*
+
+---
+
+## Required Sections
+
+Every conforming implementation **MUST** include all eight of the following sections, using these exact headings. An agent may reject an implementation that omits any required section.
+
+---
+
+### Section 1 — Platform Declaration
+
+**What it must contain:**
+
+- The target platform name and version (if version-specific)
+- The platform's native term for "container" (e.g. DATABASE, SCHEMA, DATASET)
+- The platform's native term for "access principal" (e.g. ROLE, IAM Policy)
+- Whether the platform uses a hierarchical namespace (e.g. catalog → schema → table) or a flat namespace
+- The maximum container name length enforced by the platform
+- Any reserved characters or words that must be avoided in container names
+
+**Why:** Agents must know the platform's constraints before generating any names or DDL.
+
+---
+
+### Section 2 — Container Model
+
+**What it must contain:**
+
+- Whether the implementation uses structural containers, parent containers, child containers, or any combination
+- If structural containers exist: what they hold (space allocation, administrative scope, namespace grouping) and what they must never hold (data objects)
+- If parent containers exist: what they hold (space allocation, permissions) and what they must not hold (data objects)
+- If neither structural nor parent containers exist: state that explicitly — all containers are child containers
+- The full depth of the container hierarchy, counting all levels including structural containers (e.g. four levels: structural root → structural group → parent → child; or two levels: parent → child; or one level: flat)
+- The rule for which containers may hold data objects and which may not
+- Whether physical system boundaries exist between lifecycle phases (e.g. development and production on separate systems) — and if so, the implication for agent connectivity and DDL execution scope
+
+**Why:** Agents must not place objects in structural containers, parent containers, or containers not designated for object ownership. On systems with physical boundaries, agents must not assume cross-system connectivity.
+
+---
+
+### Section 3 — Naming Pattern
+
+**What it must contain:**
+
+- The complete naming pattern expressed as an ordered sequence of segments, using `{{SegmentName}}` notation
+- For each segment:
+  - Its position in the pattern (1-based)
+  - Its data type (single character, fixed-length numeric, fixed-length alphabetic, variable-length with max)
+  - Its permitted values or the rule for deriving them
+  - Whether it is mandatory or conditional (e.g. only present in certain lifecycle phases)
+  - The separator character used between it and the next segment (underscore is conventional; implementations must state their choice)
+- A worked example of a complete container name with each segment identified
+- The ordering principle: why segments appear in this order (the spec recommends ordering from most-inclusive to least-inclusive to preserve semantic hierarchy, but does not mandate it)
+
+- The environment-agnostic naming principle: object names must be **stable across all lifecycle phases**. Only the container changes between environments — object names must never carry environment markers (e.g. `_dev`, `_uat`, `_test` suffixes on object names are prohibited). Code promotion is a container substitution, not a rename.
+
+**Why:** Agents parse container names deterministically. A fully-specified pattern enables both generation and validation without external lookups. Environment-agnostic object names ensure that promotion between phases requires no object renaming — only the target container changes.
+
+---
+
+### Section 4 — Object Placement Rules
+
+**What it must contain:**
+
+- A table mapping each recognised object type to its designated container suffix or container name rule
+- An explicit statement of the separation policy: co-located, strictly separated, or conditionally separated
+- For each object type: the abbreviated identifier used in container names (if applicable)
+- Any object types that are explicitly excluded (e.g. temporary objects that do not persist in a named container)
+
+**Minimum required object types an implementation must address:**
+
+| Object type | Must be addressed |
+|---|---|
+| Persistent tables | MUST |
+| Views | MUST |
+| Stored procedures | MUST |
+| Functions / UDFs | MUST |
+| Macros / scripts | SHOULD |
+| Indexes (if named separately) | SHOULD |
+| Temporary / transient objects | SHOULD |
+
+**Object naming rules — required declaration**
+
+The implementation must declare which of the following naming rules applies, determined by its separation policy. The two rules are mutually exclusive:
+
+**Rule A — Container-discriminated naming (applies when policy is `STRICT_SEPARATION`)**
+
+When object types are placed in separate containers, the container name is the sole type discriminator. Object names must therefore be **identical across container types** for the same logical object. Type markers — prefixes such as `v_`, `t_`, or suffixes such as `_vw`, `_tbl`, `_view` — are **prohibited** on object names. They are redundant (the container already carries the type), they break name symmetry across containers, and they prevent deterministic cross-container navigation by name substitution alone.
+
+An agent encountering a type-prefixed or type-suffixed object name in a `STRICT_SEPARATION` environment must flag it as a naming violation.
+
+**Rule B — Name-discriminated naming (applies when policy is `CO_LOCATED` or `TYPE_GROUPED`)**
+
+When object types share a container, the container cannot disambiguate type. The implementation must therefore declare an explicit disambiguation rule that produces a unique name for every `(logical_name x object_type)` combination within that container. The rule must be:
+- Declared in full in the implementation — an agent must never infer or assume it
+- Consistent — the same rule applied to every object of every type
+- Reversible — given a disambiguated name, an agent can recover the logical name and the type
+
+The implementation must document the disambiguation rule in this section and demonstrate it with at least two worked examples.
+
+An agent must never apply a disambiguation convention it has not read from the implementation. If the implementation declares `CO_LOCATED` but provides no disambiguation rule, the implementation is non-conforming and the agent must halt and report.
+
+**View-layer architecture — required declaration for implementations that include views**
+
+If the implementation uses `STRICT_SEPARATION` and views exist alongside tables, it must declare whether a view-layer architecture applies — that is, whether views are divided into tiers with different rules governing which container types each tier may reference:
+
+- If a view-tier architecture exists: the implementation must document the rules for each tier, which container types each tier may reference, and any DDL constraints that apply per tier (e.g. access locking, column list requirements). The number of tiers is unconstrained — implementations may define as many as the transformation architecture requires.
+- If no view-tier architecture exists: state that explicitly.
+
+An agent generating a view must know which tier it is working in before writing any DDL. The tier determines which containers the view may reference and which DDL patterns apply.
+
+**Why:** This is the most critical section for correct agent behaviour. Without it, agents will co-locate objects that must be separated, breaking access control models. Without the naming rule declaration, agents working in co-located environments will invent disambiguation conventions inconsistently, producing unmaintainable and unparseable object names. Without a view-tier declaration, agents may incorrectly apply access-locking patterns to transformation views, or reference table containers from views that should only reference view containers.
+
+---
+
+### Section 5 — Separation Policy
+
+**What it must contain:**
+
+- An explicit declaration of one of the following policies:
+
+  | Policy | Meaning |
+  |---|---|
+  | `STRICT_SEPARATION` | Each object type has its own designated container. Objects of different types are never in the same container. |
+  | `TYPE_GROUPED` | Object types are grouped but not strictly separated (e.g. tables and indexes together, views separately). |
+  | `CO_LOCATED` | All object types are placed in the same container. No separation by type. |
+  | `CUSTOM` | A custom rule applies. The implementation must describe it fully. |
+
+- The rationale for the chosen policy (one or two sentences)
+- Any exceptions to the policy (e.g. temporary tables may share a container with work tables)
+- The access implication of the policy: what access principals can reach, and what they cannot, as a direct consequence of this separation
+
+**Why:** Separation policy is the primary mechanism by which access control is enforced at the container level. Agents must understand it to generate correct access principal assignments.
+
+---
+
+### Section 6 — Derivation Function
+
+**What it must contain:**
+
+- A deterministic, unambiguous algorithm for computing the correct target container name for any given object
+- Expressed in pseudocode, structured natural language, or both — but it must be executable by an agent without further clarification
+- The complete set of input parameters the function accepts
+- Any conditional branches (e.g. integrated vs. workstream-level environments, production vs. development)
+- At least three worked examples covering different branches of the algorithm
+- The parent container derivation (if the platform uses parent containers) as a separate function or as a clearly identified step within the main function
+
+**The function signature must accept at minimum:**
+
+```
+derive_container(
+  object_type,        // the type of object to be placed
+  environment_inputs, // platform-specific environment identifiers
+  classification      // security or access classification, if applicable
+) → container_name
+```
+
+**Why:** This is the function agents call before every CREATE statement. It must produce a unique, unambiguous answer for every valid input combination.
+
+---
+
+### Section 7 — Access Model
+
+**What it must contain:**
+
+- The access principal model: how access is granted to containers (role-based, user-based, policy-based, or a combination)
+- Whether access is granted at the container level, the object level, or both — and which is preferred
+- The standard access principal types and what each can do (e.g. read-only role, batch role, admin role)
+- The rule for how access principals are named (if they follow a convention)
+- Any explicit prohibitions (e.g. "no direct object-level grants to end users")
+- How the separation policy interacts with access control (e.g. users with access to a view container cannot see the underlying table container)
+- Any **implied grants** created by the separation architecture — access permissions that are not granted to end-user principals directly but are required for the architecture to function. For example: if strict separation places views in one container and their source objects in another, the view-installing user or database may require elevated cross-container access rights before any view can be created. The implementation must declare these implied grants explicitly, specify when they must be provisioned (before or after object creation), and include them in the standard provisioning sequence. An agent must never treat implied grants as optional.
+
+**Why:** Agents generating data products must also generate correct access grants. Without an access model, they will either omit grants (producing inaccessible objects) or grant too broadly (producing a security violation). Implied grants created by strict separation are among the most commonly missed provisioning steps — they compile silently but fail at query time, producing error messages that appear to be view access problems rather than missing infrastructure.
+
+---
+
+### Section 8 — Validation Procedure
+
+**What it must contain:**
+
+- A platform-specific procedure, query, or checklist that confirms correct object placement after generation
+- It must be executable by an agent without human intervention
+- It must check at minimum:
+  1. Objects exist in the containers they were intended for
+  2. Objects are not present in containers designated for a different type
+  3. Objects are not present in parent containers or structural containers
+  4. End-user access principals have been granted at the correct level and not at a level that exposes containers they should not reach
+  5. All implied grants required by the separation architecture are present — their absence is a provisioning defect even if all objects were created successfully
+- The expected output of a passing validation (what "clean" looks like)
+- The expected output of a failing validation (what an agent should report)
+- The action an agent must take on failure: halt, report, and await instruction — never auto-correct silently
+
+**Why:** Generation and placement are not sufficient. Agents must verify. A silent placement error produces a working but incorrectly structured system that is expensive to remediate.
+
+---
+
+## Optional Sections
+
+Implementations MAY include any of the following. Agents should read them if present.
+
+| Section | Purpose |
+|---|---|
+| **Environment lifecycle** | How containers change across development, test, and production phases. Useful for agents generating environment-specific DDL. |
+| **Container retirement procedure** | How containers are retired when a project or workstream ends — including access revocation, object removal, and registry updates. |
+| **Metadata and tagging** | Any required metadata attached to containers at creation time. |
+| **Co-existence rules** | How this hierarchy standard co-exists with a legacy structure during migration. |
+| **Automation hooks** | Scripts, APIs, or tools that implement or validate the standard programmatically. |
+
+---
+
+## Conformance Checklist
+
+An implementation is conforming if it satisfies all of the following:
+
+- [ ] Section 1 (Platform Declaration) is present and complete
+- [ ] Section 2 (Container Model) is present and describes parent/child or flat structure
+- [ ] Section 3 (Naming Pattern) is present and all segments are fully specified
+- [ ] Section 4 (Object Placement Rules) covers all four mandatory object types (persistent tables, views, stored procedures, functions/UDFs) and declares a view-tier architecture or explicitly states that none applies
+- [ ] Section 5 (Separation Policy) declares one of the four named policies
+- [ ] Section 6 (Derivation Function) produces an unambiguous container name for any valid input
+- [ ] Section 7 (Access Model) specifies the access principal type and grant level
+- [ ] Section 8 (Validation Procedure) is executable by an agent without human input
+- [ ] All section headings match the required headings exactly (agents use these for lookup)
+- [ ] No section refers to a specific SQL dialect or platform construct in a way that would cause it to fail on a different platform (the implementation document may be platform-specific; the spec sections in a meta-document may not be)
+
+---
+
+## Non-Goals
+
+This spec does not prescribe:
+
+- Any specific naming convention (that is the implementation's responsibility)
+- Any specific SQL dialect or DDL syntax
+- Any specific access control technology
+- The number of containers in a hierarchy
+- The number of environments or lifecycle phases
+- How containers are provisioned (manual, automated, agent-driven)
+- Physical system topology — whether development and production share a system or are physically separated. This is an infrastructure decision. The naming convention must work consistently across both topologies; how objects are transported between systems is outside the scope of this standard.
+
+Those decisions belong to the organisation and are expressed in their implementation.
+
+---
+
+## Versioning
+
+Implementations should declare which version of this spec they conform to, using the `Spec version` field in their header. Breaking changes to required sections will increment the major version. Additive changes (new optional sections) will increment the minor version.
+

--- a/platform-standards/Physical_Storage_Standard_Spec.md
+++ b/platform-standards/Physical_Storage_Standard_Spec.md
@@ -1,0 +1,260 @@
+# Physical Storage Standard — Interface Specification
+
+**Version:** 1.0  
+**Status:** Normative  
+**Scope:** Any platform using object storage as the physical layer beneath a logical data container model  
+**Maintained by:** Paul Dancer — EcoSystem Architect, Teradata Worldwide Field Tech  
+**Companion standard:** Object Placement Standard — Interface Specification v1.0
+
+---
+
+## Purpose
+
+This document defines the interface that any **Physical Storage Standard** must satisfy when an organisation uses object storage (e.g. Amazon S3, Azure Data Lake Storage, Google Cloud Storage) as the physical layer beneath its logical data containers.
+
+The Object Placement Standard governs the **logical layer** — container naming, object naming, access principals. This standard governs the **physical layer** — object store paths, file formats, partition strategies, physical access controls, and data lifecycle. The two standards are explicitly coupled: the physical path is derived deterministically from the logical names defined in the Object Placement Standard. Neither standard is complete without the other when object storage is in use.
+
+This spec is **platform-agnostic**. It uses abstract terms (object store, path, bucket, partition) that map to platform-specific constructs in each implementation. It does not prescribe specific storage services, path structures, or file formats — it only prescribes what must be declared.
+
+**Relationship to the Object Placement Standard:**
+
+- The Object Placement Standard is the **primary standard**. It must exist and be conforming before a Physical Storage Standard can be written.
+- This standard **extends** the Object Placement Standard for organisations using object storage. It does not replace any section of it.
+- If an organisation uses only proprietary block storage (no object store), this standard does not apply. The Object Placement Standard alone is sufficient.
+- If object storage is used for any subset of objects, this standard applies to that subset and must declare which objects it governs.
+
+---
+
+## Terminology
+
+| Term | Meaning |
+|---|---|
+| **Object store** | A scalable, flat storage service accessed via key-value semantics. Keys are paths; values are binary objects (files). Maps to: Amazon S3, Azure Data Lake Storage (ADLS) Gen2, Google Cloud Storage (GCS), MinIO, etc. |
+| **Bucket** | The top-level named container in an object store. All paths exist within a bucket. Bucket-level policies govern coarse-grained access. |
+| **Path** | The full key used to address an object or a logical prefix (directory) in the object store. Equivalent to a file system path but with no native directory concept — the hierarchy is encoded in the key string. |
+| **Path prefix** | The portion of a path that identifies a logical grouping — equivalent to a directory. All objects whose key begins with a given prefix belong to that logical group. |
+| **Open Table Format (OTF)** | A table format specification layered over object store files that provides ACID transactions, schema evolution, time travel, and hidden partitioning. Examples: Apache Iceberg, Delta Lake, Apache Hudi. |
+| **File format** | The binary format used to encode individual data files within an OTF table. Examples: Apache Parquet, Apache ORC, Apache Avro. |
+| **Partition** | A logical subdivision of a table's data, used to improve query performance by pruning irrelevant files. May be Hive-style (encoded in the path) or hidden (managed by the OTF metadata, not in the path). |
+| **Hive-style partitioning** | Partitioning where partition values are encoded as path segments in the form `key=value`. Readable by any tool that understands Hive metastore conventions. |
+| **Hidden partitioning** | Partitioning managed entirely within the OTF metadata layer (e.g. Iceberg partition specs). The path does not encode partition values. Provides more flexibility and avoids partition key proliferation in paths. |
+| **Snapshot** | An OTF concept representing the state of a table at a point in time. Enables time travel queries. Snapshots are retained for a configurable period before expiry. |
+| **Path derivation function** | The deterministic algorithm that computes the correct object store path for a given logical object, using the logical container name and object name as inputs. |
+| **Bucket policy** | An access control policy attached to a bucket that governs which principals can perform which operations on which path prefixes. Complements but does not replace the logical access model defined in the Object Placement Standard. |
+
+---
+
+## Agent Consumption Instructions
+
+When generating any physically-stored object (typically a table or materialised view):
+
+1. **Locate** a conforming implementation of both this standard and the Object Placement Standard. Both must be present.
+2. **Derive the logical container name** using the Object Placement Standard's Derivation Function.
+3. **Derive the physical path** using this standard's Path Derivation Function, with the logical container name and object name as inputs.
+4. **Generate the DDL** with both the logical container name and the physical path — both are required for OTF table creation.
+5. **Apply the file format and partition strategy** declared in Section 5 and Section 6.
+6. **Provision physical access** — bucket policies or equivalent — as declared in Section 7, in addition to the logical access model from the Object Placement Standard.
+7. **Run both validation procedures** — the Object Placement Standard's Section 8 (logical layer) and this standard's Section 8 (physical layer).
+8. **Never invent a path** that is not derived from the declared Path Derivation Function. Ad-hoc paths break deterministic navigation and are a storage governance defect.
+
+**Priority order for locating an implementation:**
+
+1. An explicit file path provided in the current conversation or project instructions
+2. `/mnt/skills/user/physical-storage/SKILL.md`
+3. A file matching `Physical_Storage_Standard*.md` in the project context
+4. **If none of the above exist and object storage is declared in the Object Placement Standard:** STOP. Do not generate any OTF table DDL. Ask the user:
+
+   > *"The Object Placement Standard indicates object storage is in use, but I cannot find a Physical Storage Standard. Before I generate any table DDL with a storage location, I need the physical path convention, file format, and partition strategy. Please provide your Physical Storage Standard."*
+
+---
+
+## Required Sections
+
+Every conforming implementation **MUST** include all eight of the following sections, using these exact headings. An agent may reject an implementation that omits any required section.
+
+---
+
+### Section 1 — Storage Platform Declaration
+
+**What it must contain:**
+
+- The object store service (e.g. Amazon S3, ADLS Gen2, GCS) and any relevant region or configuration constraints
+- The Open Table Format in use (e.g. Apache Iceberg, Delta Lake, Apache Hudi) or a statement that no OTF is used and raw files are the storage model
+- The version of the OTF if version-specific behaviour applies
+- The logical platform this standard extends (must reference the companion Object Placement Standard implementation by name)
+- Whether this standard governs all physically-stored objects or a declared subset
+- Any objects explicitly excluded from object storage (e.g. temporary tables remain on block storage)
+
+**Why:** Agents must know the storage service, the OTF, and the scope of this standard before generating any DDL with a physical location clause.
+
+---
+
+### Section 2 — Path Model
+
+**What it must contain:**
+
+- The relationship between logical container names (from the Object Placement Standard) and physical path structure — specifically, which logical name segments map to which path segments and in which order
+- The bucket strategy: one bucket for all environments, one bucket per environment tier, one bucket per security classification, or another scheme — with rationale
+- The root prefix within the bucket (if any) — e.g. `/data/` as a root under which all table paths sit
+- Whether path segments use raw values (e.g. `A/D01/COR`) or annotated values (e.g. `prog=A/phase=D01/fn=COR`) — and which annotation style, if any
+- Whether views have physical paths (typically they do not — views are logical constructs only)
+- The handling of production paths vs development paths — whether the bucket itself provides environment separation or whether the path provides it
+
+**Why:** The path model is the coupling point between the logical standard and the physical standard. Without it, agents cannot derive paths deterministically from logical names, and physical storage becomes ungoverned.
+
+---
+
+### Section 3 — Path Derivation Pattern
+
+**What it must contain:**
+
+- The complete path pattern expressed as an ordered sequence of segments, using `{{SegmentName}}` notation consistent with the Object Placement Standard's naming segments
+- For each path segment:
+  - The logical name segment it corresponds to (or "bucket-level" if encoded in the bucket name)
+  - Its format in the path (raw value, `key=value` annotation, or other)
+  - Whether it is mandatory or conditional (e.g. absent in production paths)
+- The separator character used between segments (forward slash `/` is conventional; implementations must state their choice)
+- The trailing slash convention (include or omit on the table root prefix)
+- At least three worked examples covering different lifecycle phases
+
+**The path derivation function signature must accept at minimum:**
+
+```
+derive_path(
+  logical_container_name,  // the output of the Object Placement Standard's derive_container()
+  object_name,             // the logical object name
+  bucket                   // the target bucket (may be derived from environment inputs)
+) → fully_qualified_object_store_path
+```
+
+**Why:** Path derivation must be as deterministic as container name derivation. An agent given a logical container name and object name must be able to compute the physical path without any external lookup.
+
+---
+
+### Section 4 — File Format and Encoding
+
+**What it must contain:**
+
+- The default file format for persistent tables (e.g. Apache Parquet, Apache ORC)
+- Any permitted alternative formats and the conditions under which they apply
+- The default compression codec and any permitted alternatives
+- The schema encoding rules: how column names, data types, and nullability are represented in the file format
+- The schema evolution policy: what changes are permitted (add nullable column, rename, widen type) and which require a table drop and recreate
+- Any explicit prohibitions (e.g. CSV is never used for persistent tables; JSON is only used for staging)
+
+**Why:** File format and encoding are fixed at table creation time for most OTF implementations. An agent generating a CREATE TABLE statement must apply the correct format. Inconsistent formats across tables in the same logical layer produce heterogeneous storage that is expensive to maintain and migrate.
+
+---
+
+### Section 5 — Partition Strategy
+
+**What it must contain:**
+
+- The partitioning model in use: Hive-style, hidden (OTF-managed), none, or a combination
+- If hidden partitioning: the partition spec pattern (e.g. partition by month on `created_date`) — which columns are used as partition keys and by what transform (identity, year, month, day, hour, bucket, truncate)
+- If Hive-style: how partition key=value pairs appear in the path and whether they are included in the Path Derivation Pattern from Section 3
+- The rule for selecting partition keys: what criteria determine whether a column is a partition key (e.g. high-cardinality columns are excluded; time-based columns are preferred)
+- The maximum number of partition columns and the rationale
+- How partition evolution is handled when the partition spec changes for an existing table
+
+**Why:** Partition strategy directly affects query performance, file counts, and path structure. An agent generating table DDL must apply the correct partition spec. An incorrect partition (or none at all) can make tables unusable at scale.
+
+---
+
+### Section 6 — Retention and Lifecycle
+
+**What it must contain:**
+
+- The default data retention period for each logical layer (e.g. staging: 7 days; core model: indefinite; temporary: 24 hours)
+- The OTF snapshot retention period — how long historical snapshots are retained before expiry (relevant for time travel queries)
+- The orphan file cleanup policy — how frequently unreferenced files are removed
+- The object store lifecycle rule (if any) — automatic tiering to cheaper storage classes after a defined period
+- The workstream retirement procedure at the physical layer: what happens to the object store paths when a workstream is decommissioned (delete, archive, or transfer)
+- Who or what is responsible for executing lifecycle actions (a scheduled agent, a human DBA, an automated pipeline)
+
+**Why:** Object store costs accumulate with data volume and snapshot count. Unmanaged retention produces unbounded storage costs, orphaned files, and compliance risks. Agents provisioning tables must understand the lifecycle rules that govern what they create.
+
+---
+
+### Section 7 — Access Model
+
+**What it must contain:**
+
+- The physical access model: bucket policies, IAM roles, access control lists, or a combination — and how they relate to the logical access model defined in the companion Object Placement Standard
+- The mapping between logical access principals (roles from the Object Placement Standard) and physical access principals (IAM roles, service accounts, managed identities)
+- The principle governing the relationship: physical access must never exceed logical access. A principal with SELECT on a logical view container must not have direct object store read access to the underlying table's physical path.
+- The bucket policy structure: which path prefixes map to which access permissions, and how security classification segments in the path are used to enforce tiered access
+- Any access controls that apply at the bucket level (e.g. production bucket requires MFA delete; development bucket allows broader read access)
+- The handling of cross-service access: if external tools (Spark, Athena, dbt, Glue) access the object store directly, how their access is governed and audited
+
+**Why:** Object store access bypasses the logical access model entirely. A principal with IAM read access to an S3 prefix can read the raw Parquet files without going through any view layer or role-based grant. The physical access model must mirror and reinforce the logical model — not create a bypass around it.
+
+---
+
+### Section 8 — Validation Procedure
+
+**What it must contain:**
+
+- A platform-specific procedure, query, or checklist that confirms correct physical placement after generation
+- It must be executable by an agent without human intervention
+- It must check at minimum:
+  1. The object store path exists and matches the output of the Path Derivation Function for the logical container and object name
+  2. The file format of data files matches the declared default (Section 4)
+  3. The partition spec of the table matches the declared partition strategy (Section 5)
+  4. No data files exist at paths that do not conform to the declared path pattern (orphan or misplaced files)
+  5. Physical access principals are correctly scoped — no IAM principal has broader physical access than their logical access model permits
+- The expected output of a passing validation
+- The expected output of a failing validation and the action an agent must take: halt, report, await instruction — never auto-correct silently
+
+**Why:** Physical storage errors are silent. A table created at the wrong path will appear to work until the path convention matters — for backup, for lifecycle management, for external tool access, or for decommissioning. By then, data may have accumulated in the wrong location and remediation is expensive.
+
+---
+
+## Optional Sections
+
+Implementations MAY include any of the following. Agents should read them if present.
+
+| Section | Purpose |
+|---|---|
+| **External catalogue integration** | How the OTF table metadata is registered in an external catalogue (AWS Glue, Hive Metastore, Unity Catalog, etc.) and what the agent must do to keep the catalogue consistent with physical storage. |
+| **Cross-platform access** | Rules governing access to OTF tables by external compute engines (Spark, Trino, Athena, dbt) — path conventions, credential management, and audit requirements. |
+| **Disaster recovery** | Cross-region replication, backup strategy, and recovery time objectives for object store data. |
+| **Cost allocation** | How storage costs are attributed to programmes, workstreams, or business units using path-based tagging. |
+| **Migration procedure** | How existing BFS (block file storage) tables are migrated to OFS without disruption to consumers. |
+
+---
+
+## Conformance Checklist
+
+An implementation is conforming if it satisfies all of the following:
+
+- [ ] Section 1 (Storage Platform Declaration) names the object store service and OTF in use
+- [ ] Section 2 (Path Model) declares the bucket strategy and the relationship between logical names and physical paths
+- [ ] Section 3 (Path Derivation Pattern) provides a deterministic function that produces a unique path for any valid logical name and object name combination
+- [ ] Section 4 (File Format and Encoding) declares the default format, compression, and schema evolution policy
+- [ ] Section 5 (Partition Strategy) declares the partitioning model and partition key selection rules
+- [ ] Section 6 (Retention and Lifecycle) declares retention periods for each logical layer and the workstream retirement procedure
+- [ ] Section 7 (Access Model) maps logical access principals to physical access principals and states the non-bypass principle
+- [ ] Section 8 (Validation Procedure) is executable by an agent and covers all five minimum checks
+- [ ] All section headings match the required headings exactly
+- [ ] The companion Object Placement Standard implementation is named in Section 1
+
+---
+
+## Non-Goals
+
+This standard does not prescribe:
+
+- The Object Placement Standard's concerns (logical container naming, object naming, logical access model)
+- Which object store service to use
+- Which Open Table Format to use
+- Compute engine choice (Spark, Trino, Teradata, etc.)
+- Data modelling methodology (Data Vault, dimensional, etc.)
+- How data arrives in the object store (streaming, batch, CDC)
+- Query performance optimisation beyond partition strategy
+
+---
+
+## Versioning
+
+Implementations should declare which version of this spec they conform to, using the `Spec version` field in their header. This standard versions independently of the Object Placement Standard. Breaking changes increment the major version; additive changes increment the minor version.


### PR DESCRIPTION
- New Section 6 advocates reading through views without prescribing where tables and views are placed
- Defers container naming, separation, access, and validation to the Object Placement Standard (interface spec + platform implementations)
- Lists builder/agent behaviour: locate a conforming Object Placement Standard before generating any object; halt and ask if absent
- Section 6.5 references point to platform-standards/ (spec, same repo) and remi-td/data-products-builder/standards/ (Teradata implementation)
- Sections 6–11 renumbered to 7–12; ToC updated including previously missing Section 11 (Platform Implementation Guidance: Teradata)
- Version bumped to 1.6