### PR TITLE
feat(views): add explicit column contracts to all CREATE/REPLACE VIEW defintion

### DIFF
--- a/design-standards/Advocated_Data_Management_Standards.md
+++ b/design-standards/Advocated_Data_Management_Standards.md
@@ -828,7 +828,23 @@ WHERE p.is_current = 1;
 
 ```sql
 -- Create view to simplify agent queries
-CREATE VIEW Party_Complete AS
+CREATE VIEW Party_Complete
+(
+    -- View contract: agents see all returned columns without parsing the SELECT body
+    party_id,
+    party_key,
+    legal_name,
+    valid_from_dts,
+    valid_to_dts,
+    last_changed_by,
+    last_changed_dts,
+    change_reason,
+    source_system,
+    batch_id,
+    quality_score,
+    quality_evaluated_dts
+)
+AS
 SELECT 
     p.party_id, p.party_key, p.legal_name,
     p.valid_from_dts, p.valid_to_dts,
@@ -1028,7 +1044,17 @@ WHERE p.is_current = 1
 ### 8.4 Advocated: Use Views for Agent Access
 
 ```sql
-CREATE VIEW Party_HighQuality AS
+CREATE VIEW Party_HighQuality
+(
+    -- View contract: agents see all returned columns without parsing the SELECT body
+    party_id,
+    party_key,
+    legal_name,
+    quality_score,
+    evaluated_dts,
+    rule_results_json
+)
+AS
 SELECT p.party_id, p.party_key, p.legal_name,
        dq.quality_score, dq.evaluated_dts,
        dq.rule_results_json

--- a/design-standards/Domain_Module_Design_Standard.md
+++ b/design-standards/Domain_Module_Design_Standard.md
@@ -305,19 +305,61 @@ CREATE TABLE PartyRole_H (
 
 ```sql
 -- Standard view pattern 1: Current active records
-CREATE VIEW Party_Current AS
-SELECT * FROM Party_H
-WHERE is_current = 1 AND is_deleted = 0;
+-- View contract makes returned columns explicit — agents read the header, not the SELECT body
+CREATE VIEW Party_Current
+(
+    party_id,
+    party_key,
+    legal_name,
+    tax_identifier,
+    valid_from_dts,
+    valid_to_dts
+    -- ... all remaining Party_H columns listed explicitly
+)
+AS
+SELECT
+    party_id,
+    party_key,
+    legal_name,
+    tax_identifier,
+    valid_from_dts,
+    valid_to_dts
+    -- ... all remaining Party_H columns
+FROM Party_H
+WHERE is_current = 1
+  AND is_deleted = 0;
 
-CREATE VIEW Product_Current AS
-SELECT * FROM Product_H
-WHERE is_current = 1 AND is_deleted = 0;
+CREATE VIEW Product_Current
+(
+    product_id,
+    product_key,
+    -- ... all remaining Product_H columns listed explicitly
+)
+AS
+SELECT
+    product_id,
+    product_key
+    -- ... all remaining Product_H columns
+FROM Product_H
+WHERE is_current = 1
+  AND is_deleted = 0;
 
 -- Agent learns: "{Entity}_Current views always give me active records"
 
 -- Standard view pattern 2: Enriched with common joins
-CREATE VIEW Party_Enriched AS
-SELECT p.*, [common join data]
+CREATE VIEW Party_Enriched
+(
+    party_id,
+    party_key,
+    legal_name,
+    -- ... all Party_H columns plus joined columns, listed explicitly
+)
+AS
+SELECT
+    p.party_id,
+    p.party_key,
+    p.legal_name,
+    [common join data]
 FROM Party_Current p
 LEFT JOIN [common related data];
 
@@ -739,18 +781,38 @@ WHERE pred.is_current = 1;
 
 ```sql
 -- Current version view (always create)
-CREATE VIEW {Entity}_Current AS
-SELECT {entity}_id, {entity}_key, [business columns]
+-- View contract makes returned columns explicit — agents read the header, not the SELECT body
+CREATE VIEW {Entity}_Current
+(
+    {entity}_id,
+    {entity}_key,
+    [all business columns listed explicitly]
+)
+AS
+SELECT
+    {entity}_id,
+    {entity}_key,
+    [business columns]
 FROM {Entity}_H
-WHERE is_current = 1 AND is_deleted = 0;
+WHERE is_current = 1
+  AND is_deleted = 0;
 
 COMMENT ON VIEW {Entity}_Current IS 
 'Current active {entity} records - filters to current non-deleted versions for simplified querying';
 
 -- Enriched view (when joining to other modules is common)
-CREATE VIEW {Entity}_Enriched AS
+CREATE VIEW {Entity}_Enriched
+(
+    {entity}_id,
+    {entity}_key,
+    [all business columns from {Entity}_Current],
+    [all additional columns from joined modules, listed explicitly]
+)
+AS
 SELECT 
-    e.*,
+    e.{entity}_id,
+    e.{entity}_key,
+    [all business columns],
     [columns from other modules]
 FROM {Entity}_Current e
 LEFT JOIN [other modules];

--- a/design-standards/Memory_Module_Design_Standard.md
+++ b/design-standards/Memory_Module_Design_Standard.md
@@ -844,7 +844,25 @@ WHERE success_count * 1.0 / total_count > 0.8;
 
 ```sql
 -- View: Agent interactions summary (no JSON parsing needed!)
-CREATE VIEW Memory.v_interactions_summary AS
+CREATE VIEW Memory.v_interactions_summary
+(
+    -- View contract: agents see all returned columns without parsing the SELECT body
+    session_id,
+    interaction_seq,
+    interaction_type,
+    user_input,
+    action_taken,
+    sql_executed,
+    query_result_count,
+    execution_time_ms,
+    outcome_status,
+    user_feedback,
+    referenced_tables,
+    scope_level,
+    scope_identifier,
+    interaction_dts
+)
+AS
 SELECT 
     ai.session_id,
     ai.interaction_seq,

--- a/design-standards/Observability_Module_Design_Standard.md
+++ b/design-standards/Observability_Module_Design_Standard.md
@@ -561,7 +561,25 @@ The following views are deployed into the `{ProductName}_Semantic` database to e
 Transforms the **definitional** `data_lineage` table into a two-leg edge list (source → job, job → target) compatible with typically used Graph standards. Reads active flows only — no duplicate edges from repeated executions.
 
 ```sql
-REPLACE VIEW Semantic.lineage_graph AS
+REPLACE VIEW Semantic.lineage_graph
+(
+    -- View contract: agents see all returned columns without parsing the SELECT body
+    Src_Object_Name_FQ,
+    Src_Container_Name,
+    Src_Object_Name,
+    Src_Kind,
+    Src_Display_Name,
+    Edge_Relationship,
+    Transformation_Type,
+    Transformation_Logic,
+    Lineage_ID,
+    Tgt_Object_Name_FQ,
+    Tgt_Container_Name,
+    Tgt_Object_Name,
+    Tgt_Kind,
+    Tgt_Display_Name
+)
+AS
 /*
  * lineage_graph
  * ───────────────
@@ -721,7 +739,27 @@ LOCKING ROW FOR ACCESS
 Convenience view joining each active lineage definition to its most recent execution. Useful for dashboards showing "last run status" alongside the blueprint.
 
 ```sql
-REPLACE VIEW Semantic.lineage_run_latest AS
+REPLACE VIEW Semantic.lineage_run_latest
+(
+    -- View contract: agents see all returned columns without parsing the SELECT body
+    lineage_id,
+    source_database,
+    source_table,
+    job_name,
+    target_database,
+    target_table,
+    transformation_type,
+    is_active,
+    lineage_run_id,
+    last_run_dts,
+    last_run_status,
+    last_run_duration_ms,
+    last_records_read,
+    last_records_written,
+    last_records_rejected,
+    last_error_message
+)
+AS
 LOCKING ROW FOR ACCESS
 SELECT
      dl.lineage_id

--- a/design-standards/Prediction_Module_Design_Standard.md
+++ b/design-standards/Prediction_Module_Design_Standard.md
@@ -672,7 +672,18 @@ WHERE entity_id = 1001
 
 ```sql
 -- View 1: Current features only (engineered features from Prediction)
-CREATE VIEW Prediction.v_customer_features_current AS
+CREATE VIEW Prediction.v_customer_features_current
+(
+    -- View contract: agents see all returned columns without parsing the SELECT body
+    party_id,
+    age_normalized,
+    income_normalized,
+    credit_score_normalized,
+    recency_score,
+    transaction_velocity,
+    observation_dts
+)
+AS
 SELECT 
     cf.party_id,
     cf.age_normalized,        -- Engineered: normalized to 0-1
@@ -689,7 +700,23 @@ COMMENT ON VIEW Prediction.v_customer_features_current IS
 
 -- View 2: Features with Domain context (JOIN without duplication)
 -- This pattern avoids duplicating domain attributes in Prediction module
-CREATE VIEW Prediction.v_customer_features_enriched AS
+CREATE VIEW Prediction.v_customer_features_enriched
+(
+    -- View contract: agents see all returned columns without parsing the SELECT body
+    party_key,
+    legal_name,
+    party_type_code,
+    birth_date,
+    annual_income_amt,
+    credit_limit_amt,
+    age_normalized,
+    income_normalized,
+    credit_score_normalized,
+    recency_score,
+    transaction_velocity,
+    observation_dts
+)
+AS
 SELECT 
     -- Domain attributes (NOT duplicated in Prediction)
     p.party_key,
@@ -717,7 +744,18 @@ COMMENT ON VIEW Prediction.v_customer_features_enriched IS
 
 -- View 3: Point-in-Time Feature Reconstruction
 -- For training with historical features
-CREATE VIEW Prediction.v_customer_features_pit AS
+CREATE VIEW Prediction.v_customer_features_pit
+(
+    -- View contract: agents see all returned columns without parsing the SELECT body
+    party_key,
+    legal_name,
+    age_normalized,
+    income_normalized,
+    observation_dts,
+    valid_from_dts,
+    valid_to_dts
+)
+AS
 SELECT 
     p.party_key,
     p.legal_name,

--- a/design-standards/Search_Module_Design_Standard.md
+++ b/design-standards/Search_Module_Design_Standard.md
@@ -525,7 +525,20 @@ INSERT INTO Search.party_embedding (
 
 ```sql
 -- View combines embeddings with actual content (efficient join)
-CREATE VIEW Search.v_party_searchable AS
+CREATE VIEW Search.v_party_searchable
+(
+    -- View contract: agents see all returned columns without parsing the SELECT body
+    party_id,
+    party_key,
+    legal_name,
+    description,
+    notes,
+    embedding_vector,
+    embedding_model,
+    embedding_dimensions,
+    generated_dts
+)
+AS
 SELECT 
     -- Entity identification
     p.party_id,

--- a/design-standards/Semantic_Module_Design_Standard.md
+++ b/design-standards/Semantic_Module_Design_Standard.md
@@ -439,7 +439,17 @@ COMMENT ON COLUMN Semantic.table_relationship.updated_at IS
 ### 5.1 v_relationship_paths View (TESTED ✅)
 
 ```sql
-CREATE VIEW Semantic.v_relationship_paths AS
+CREATE VIEW Semantic.v_relationship_paths
+(
+    -- View contract: agents see all returned columns without parsing the SELECT body
+    source_table,
+    target_table,
+    path_tables,
+    path_joins,
+    hop_count,
+    path_description
+)
+AS
 WITH RECURSIVE relationship_paths (
     source_table,
     target_table,


### PR DESCRIPTION
**Summary**
Add view column contracts (the parenthesised column list between the view name and the AS keyword) to every view defined across the design standards. Agents can now determine a view's full output schema from its DDL header without parsing the SELECT body.

A governed view should explicitly declare its published column contract in the view column list immediately after the view name. 

The declared column list must match the select-list by ordinal position and should be treated as the externally visible interface of the view.

**Benefits**
 - The exposed column names are controlled in one obvious place.
 - The select list can use complex expressions without relying on expression aliases.
 - The view interface is stable even if source column names change.
 - The contract is ordinally explicit: column 1 maps to select expression 1, and so on.
 - Generated views become easier to validate because the declared contract column count must match the select-list column count.

For an agentic or metadata-driven framework, that is useful because the file has a clear, easily parseable contract section.

**Files changed:**
- Domain_Module_Design_Standard.md      — illustrative Party_Current,
  Product_Current, Party_Enriched examples + {Entity}_Current /
  {Entity}_Enriched templates
- Memory_Module_Design_Standard.md      — v_interactions_summary (14 cols)
- Observability_Module_Design_Standard.md — lineage_graph (14 cols),
  lineage_run_latest (16 cols)
- Prediction_Module_Design_Standard.md  — v_customer_features_current (7),
  v_customer_features_enriched (12), v_customer_features_pit (7)
- Search_Module_Design_Standard.md      — v_party_searchable (9 cols)
- Semantic_Module_Design_Standard.md    — v_relationship_paths (6 cols)
- Advocated_Data_Management_Standards.md — Party_Complete (12 cols),
  Party_HighQuality (6 cols)