### PR TITLE
Add data product orientation layer

### DIFF
--- a/design-standards/Memory_Module_Design_Standard.md
+++ b/design-standards/Memory_Module_Design_Standard.md
@@ -1,5 +1,5 @@
 # Memory Module Design Standard
-## AI-Native Data Product Architecture - Version 1.8
+## AI-Native Data Product Architecture - Version 1.9
 
 ---
 
@@ -7,9 +7,9 @@
 
 | Attribute | Value |
 |-----------|-------|
-| **Version** | 1.8 |
+| **Version** | 1.9 |
 | **Status** | STANDARD |
-| **Last Updated** | 2026-05-29 |
+| **Last Updated** | 2026-05-30 |
 | **Owner** | Nathan Green, Worldwide Data Architecture Team, Teradata |
 | **Scope** | Memory Module (Agent State, Learning & Documentation Sub-Module) |
 | **Type** | Design Standard (Structural Requirements) |
@@ -1042,15 +1042,44 @@ At a minimum, the following design decisions must be documented at first deploym
 |---|---|
 | `DD-SCOPE-001` | Database layout choice (separate databases per module vs. single database) |
 | `DD-SCOPE-002` | Which modules are in scope and which are deferred or excluded, with rationale |
+| `DD-DISCOVERY-001` | Data Product Orientation Layer: why agents read the product manifest before metadata maps or data |
 | `DD-{MODULE}-001` | Each module's primary index strategy and temporal pattern choice |
 
 Any deviation from the AI-Native Data Product design standards must also be captured as a `Design_Decision` with `decision_category = 'ARCHITECTURE'`. See Section 7.3 for the deviation convention.
+
+Every data product that exposes a Data Product Orientation Layer must capture the rationale in Memory. The purpose of this row is to make the manifest-first discovery contract self-describing to future agents, not just visible in repository history.
+
+```sql
+INSERT INTO Memory.Design_Decision (
+    decision_id, decision_version, decision_title,
+    decision_description, context, alternatives_considered,
+    rationale, consequences,
+    decision_status, decision_category,
+    source_module, module_version, affects_table,
+    decided_by, decided_date,
+    valid_from, valid_to, is_current,
+    created_timestamp, updated_timestamp
+) VALUES (
+    'DD-DISCOVERY-001', 1,
+    'Expose a Data Product Orientation Layer before metadata and data access',
+    'Agents and MCP clients list products, read the selected product manifest, inspect contract, semantic model, policy, quality, lineage, and physical map, and only then query data through the approved access path.',
+    'data_product_map is a module inventory inside the Semantic module. It does not tell a client which product version is current, which metadata surface to query first, which policies apply, or which data entrypoint is approved.',
+    'Continue deriving Semantic database names by convention; query data_product_map first; expose physical schemas first; or publish the discovery contract only in external documentation.',
+    'A manifest-first orientation layer gives clients a safe product-level handshake: discover products, read the manifest, follow recommended navigation, and keep data access behind approved entrypoints backed by policy and quality context.',
+    'Agents have a deterministic bootstrap path and do not need to guess where to start. Product owners must maintain the manifest and registry rows, including inactive or deleted products using BYTEINT lifecycle flags.',
+    'ACCEPTED', 'ARCHITECTURE',
+    'SEMANTIC', '2.7.0', 'governance.data_product_registry',
+    'Worldwide Data Architecture Team', CURRENT_DATE,
+    CURRENT_DATE, DATE '9999-12-31', 1,
+    CURRENT_TIMESTAMP(6), CURRENT_TIMESTAMP(6)
+);
+```
 
 #### Query_Cookbook — minimum entries
 
 | Recipe ID pattern | Required content |
 |---|---|
-| `QC-SEMANTIC-001` | Agent bootstrap: query `data_product_map` then `entity_metadata` |
+| `QC-SEMANTIC-001` | Agent bootstrap: read product manifest, then query `data_product_registry`, `data_product_map`, and `entity_metadata` as needed |
 | `QC-SEMANTIC-002` | ERD generation: query `table_relationship` to produce entity-relationship output |
 | `QC-{MODULE}-001` | At least one representative query per deployed module |
 | `QC-XMODULE-{NNN}` | At least one cross-module join example per deployed module pair |
@@ -1105,6 +1134,7 @@ This is not a compliance step — it is how the data product communicates design
 - [ ] Privacy policies documented
 - [ ] `Module_Registry` INSERT generated for **every module considered** (DEPLOYED, PLANNED, or DEPRECATED)
 - [ ] `Design_Decision` entries generated for all deferred/excluded modules
+- [ ] `DD-DISCOVERY-001` generated when the Data Product Orientation Layer is deployed
 - [ ] Min. 3 `Design_Decision` INSERTs generated per deployed module
 - [ ] All deviations from design standards captured in `Design_Decision`
 - [ ] `Change_Log` initial release entry generated
@@ -1824,6 +1854,7 @@ Discovered Patterns:    Indefinite if validated
 
 | Version | Date | Changes | Author |
 |---------|------|---------|--------|
+| 1.9 | 2026-05-30 | Added `DD-DISCOVERY-001` as the required native Memory decision record for the Data Product Orientation Layer. Updated the Semantic bootstrap recipe requirement so agents read the product manifest before metadata maps or data access, preserving the rationale inside the data product itself. | Paul Dancer, Worldwide Data Architecture Team, Teradata |
 | 1.8 | 2026-05-29 | Clarified `Query_Cookbook` lifecycle requirements. Documented `is_active`, `valid_from`, `valid_to`, `created_timestamp`, and `updated_timestamp` as the standard columns for active-row filtering, temporal validity, auditability, and append-oriented recipe correction. Updated the standard ERD recipe seed template to populate timestamp columns explicitly. | Paul Dancer, Worldwide Data Architecture Team, Teradata |
 | 1.7 | 2026-04-15 | Added `deployment_status VARCHAR(20) NOT NULL DEFAULT 'DEPLOYED'` to `Module_Registry` DDL, enabling DEPLOYED/PLANNED/DEPRECATED lifecycle tracking for all modules considered during design. Expanded Section 7 with Minimum Seed Data Requirements (7.2), Deviation Documentation Convention (7.3), updated Design Checklist (7.4), and Quality Criteria (7.5). Key additions: Module_Registry row required for every module considered; Design_Decision entries required for deferred/excluded modules and all standards deviations; ERD generation recipe (QC-SEMANTIC-002) mandatory; cross-module cookbook recipes required per deployed module pair. Added standard ERD recipe INSERT template to Section 8.4. | Nathan Green, Worldwide Data Architecture Team, Teradata |
 | 1.6 | 2026-03-20 | Fixed = 'Y' filter value in Search integration example (Section 6.3) to = 1. | Nathan Green, Worldwide Data Architecture Team, Teradata |

--- a/design-standards/Semantic_Module_Design_Standard.md
+++ b/design-standards/Semantic_Module_Design_Standard.md
@@ -1,5 +1,5 @@
 # Semantic Module Design Standard
-## AI-Native Data Product Architecture - Version 2.6 (Tested & Validated)
+## AI-Native Data Product Architecture - Version 2.7 (Tested & Validated)
 
 ---
 
@@ -7,9 +7,9 @@
 
 | Attribute | Value |
 |-----------|-------|
-| **Version** | 2.6 |
+| **Version** | 2.7 |
 | **Status** | STANDARD - Tested on Teradata |
-| **Last Updated** | 2026-03-20 |
+| **Last Updated** | 2026-05-30 |
 | **Owner** | Nathan Green, Worldwide Data Architecture Team, Teradata |
 | **Scope** | Semantic Module (Knowledge & Meaning) |
 | **Type** | Design Standard (Structural Requirements) |
@@ -246,7 +246,221 @@ COMMENT ON COLUMN Semantic.naming_standard.created_at IS
 'Timestamp when naming standard was documented';
 ```
 
-### 3.4 data_product_map (Module Discovery)
+### 3.4 data_product_registry (Product Discovery)
+
+**Purpose**: Enable agents and MCP clients to discover the data product, its current metadata contract, and its approved data access entrypoint before navigating module metadata or querying data.
+
+`data_product_registry` is the product-level storage anchor for the **Data Product Orientation Layer**. It complements `data_product_map`: agents and MCP clients discover the product and read its manifest first, then use the manifest to locate the product's contract, Semantic model, Memory guidance, Observability evidence, policy, quality, lineage, physical map, and approved data access surfaces. They then query `data_product_map` inside the Semantic module for deployed module locations.
+
+The key principle is **product first, not tables first**. Clients must not start by guessing physical databases or listing tables.
+
+```sql
+CREATE MULTISET TABLE governance.data_product_registry
+(
+    product_id             VARCHAR(128) NOT NULL
+   ,product_name           VARCHAR(256) NOT NULL
+   ,product_version        VARCHAR(32) NOT NULL
+   ,product_description    VARCHAR(1000)
+   ,product_status         VARCHAR(32) NOT NULL
+   ,owner_team             VARCHAR(256)
+   ,semantic_database      VARCHAR(128)
+   ,memory_database        VARCHAR(128)
+   ,observability_database VARCHAR(128)
+   ,manifest_json          CLOB
+   ,contract_uri           VARCHAR(1000)
+   ,semantic_uri           VARCHAR(1000)
+   ,quality_uri            VARCHAR(1000)
+   ,lineage_uri            VARCHAR(1000)
+   ,policy_uri             VARCHAR(1000)
+   ,glossary_uri           VARCHAR(1000)
+   ,query_cookbook_uri     VARCHAR(1000)
+   ,approved_entrypoint    VARCHAR(1000)
+   ,approved_access_mode   VARCHAR(32)
+   ,is_active              BYTEINT NOT NULL
+   ,is_deleted             BYTEINT NOT NULL
+   ,created_at             TIMESTAMP(6) WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP(6)
+   ,updated_at             TIMESTAMP(6) WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP(6)
+)
+PRIMARY INDEX (product_id);
+
+COMMENT ON TABLE governance.data_product_registry IS
+'Product-level registry - agents and MCP clients discover current data products, metadata contracts, and approved access entrypoints';
+
+COMMENT ON COLUMN governance.data_product_registry.product_id IS
+'Stable product identifier used by agents, MCP resources, manifests, lineage, policies, and contracts';
+
+COMMENT ON COLUMN governance.data_product_registry.product_name IS
+'Human-readable data product name';
+
+COMMENT ON COLUMN governance.data_product_registry.product_version IS
+'Current data product contract or release version';
+
+COMMENT ON COLUMN governance.data_product_registry.product_description IS
+'Business description of the product purpose, scope, and intended consumers';
+
+COMMENT ON COLUMN governance.data_product_registry.product_status IS
+'Lifecycle status - DRAFT, ACTIVE, DEPRECATED, or RETIRED';
+
+COMMENT ON COLUMN governance.data_product_registry.owner_team IS
+'Owning team or steward responsible for product contract, policy, and support';
+
+COMMENT ON COLUMN governance.data_product_registry.semantic_database IS
+'Semantic module database to query after registry discovery';
+
+COMMENT ON COLUMN governance.data_product_registry.memory_database IS
+'Memory module database containing Business_Glossary, Query_Cookbook, and design memory';
+
+COMMENT ON COLUMN governance.data_product_registry.observability_database IS
+'Observability module database containing lineage, quality, and usage telemetry where deployed';
+
+COMMENT ON COLUMN governance.data_product_registry.manifest_json IS
+'Machine-readable product orientation manifest for agents and MCP clients';
+
+COMMENT ON COLUMN governance.data_product_registry.contract_uri IS
+'URI for the product contract or external contract document';
+
+COMMENT ON COLUMN governance.data_product_registry.semantic_uri IS
+'URI for Semantic metadata, an MCP resource, or related documentation';
+
+COMMENT ON COLUMN governance.data_product_registry.quality_uri IS
+'URI for data quality rules, reports, or MCP resource';
+
+COMMENT ON COLUMN governance.data_product_registry.lineage_uri IS
+'URI for lineage metadata, graph, or MCP resource';
+
+COMMENT ON COLUMN governance.data_product_registry.policy_uri IS
+'URI for policy, usage, classification, or access-control guidance';
+
+COMMENT ON COLUMN governance.data_product_registry.glossary_uri IS
+'URI for business glossary metadata, typically backed by Memory.Business_Glossary';
+
+COMMENT ON COLUMN governance.data_product_registry.query_cookbook_uri IS
+'URI for validated query recipes, typically backed by Memory.Query_Cookbook';
+
+COMMENT ON COLUMN governance.data_product_registry.approved_entrypoint IS
+'Approved first data access surface, such as an access view, semantic view, or MCP tool resource';
+
+COMMENT ON COLUMN governance.data_product_registry.approved_access_mode IS
+'Approved access mode - VIEW, MCP_TOOL, SEMANTIC_QUERY, or site-defined equivalent';
+
+COMMENT ON COLUMN governance.data_product_registry.is_active IS
+'Registry row active indicator - 1 = current and discoverable, 0 = inactive';
+
+COMMENT ON COLUMN governance.data_product_registry.is_deleted IS
+'Soft delete indicator - 1 = logically deleted and hidden from discovery, 0 = discoverable when active';
+
+COMMENT ON COLUMN governance.data_product_registry.created_at IS
+'Timestamp when registry record was created';
+
+COMMENT ON COLUMN governance.data_product_registry.updated_at IS
+'Timestamp when registry record was last updated';
+```
+
+#### Data Product Orientation Layer
+
+MCP servers should expose the orientation layer as resources first and tools second.
+
+**Resources provide context**: product lists, manifests, contracts, schemas, policies, quality evidence, lineage, and physical maps.
+
+**Tools perform actions**: searching products, describing a product, choosing an entrypoint, querying approved data, or explaining an access path.
+
+```text
+/resources
+  /products
+  /products/{product_id}/manifest
+  /products/{product_id}/contract
+  /products/{product_id}/semantic
+  /products/{product_id}/lineage
+  /products/{product_id}/quality
+  /products/{product_id}/policy
+  /products/{product_id}/physical-map
+
+/tools
+  search_data_products
+  describe_data_product
+  get_recommended_entrypoint
+  query_product_data
+  explain_access_path
+```
+
+**Metadata-first handshake**:
+
+1. Client asks what products are available.
+2. Server returns products and manifest resources.
+3. Client reads the selected product manifest.
+4. Server recommends navigation: contract, semantic model, policy, quality, lineage, physical map, approved data access.
+5. Client queries data only through the approved access path.
+
+#### Discovery Manifest
+
+The manifest is the first resource an MCP client should read after selecting a product. It can be stored in `manifest_json` and exposed as `/products/{product_id}/manifest`.
+
+```yaml
+data_product_id: call_centre.customer_experience
+name: Customer Experience Data Product
+version: 1.0.0
+
+entrypoints:
+  orientation: mcp://products/call_centre/customer_experience/manifest
+  contract: mcp://products/call_centre/customer_experience/contract
+  semantic_model: mcp://products/call_centre/customer_experience/semantic
+  lineage: mcp://products/call_centre/customer_experience/lineage
+  quality: mcp://products/call_centre/customer_experience/quality
+  policy: mcp://products/call_centre/customer_experience/access-policy
+  data_access: mcp://products/call_centre/customer_experience/data
+
+recommended_navigation:
+  - contract
+  - semantic_model
+  - policy
+  - quality
+  - lineage
+  - data_access
+```
+
+The manifest should tell the agent what the product is, what it means, what it trusts, what the agent may access, and how to proceed.
+
+**MCP Catalog Query**:
+```sql
+-- MCP client discovers all current, discoverable data products
+SELECT product_id,
+       product_name,
+       product_version,
+       product_description,
+       product_status,
+       owner_team,
+       semantic_database,
+       memory_database,
+       observability_database,
+       contract_uri,
+       semantic_uri,
+       quality_uri,
+       lineage_uri,
+       policy_uri,
+       glossary_uri,
+       query_cookbook_uri,
+       approved_entrypoint,
+       approved_access_mode
+FROM governance.data_product_registry
+WHERE is_active = 1
+  AND is_deleted = 0;
+```
+
+**Expected MCP resource shape**:
+
+```text
+mcp://products
+mcp://products/{product_id}/manifest
+mcp://products/{product_id}/contract
+mcp://products/{product_id}/semantic
+mcp://products/{product_id}/lineage
+mcp://products/{product_id}/quality
+mcp://products/{product_id}/access-policy
+mcp://products/{product_id}/physical-map
+mcp://products/{product_id}/data
+```
+
+### 3.5 data_product_map (Module Discovery)
 
 **Purpose**: Enable agents to discover which modules are deployed and where they are physically located
 
@@ -557,6 +771,18 @@ QUALIFY ROW_NUMBER() OVER (ORDER BY hop_count) = 1;
 ### 6.1 Discovery Queries
 
 ```sql
+-- Which data products are currently discoverable?
+SELECT product_id, product_name, semantic_database, approved_entrypoint
+FROM governance.data_product_registry
+WHERE is_active = 1
+  AND is_deleted = 0;
+
+-- Which modules are deployed for the selected product?
+SELECT module_name, database_name, primary_tables, primary_views
+FROM Semantic.data_product_map
+WHERE is_active = 1
+ORDER BY module_name;
+
 -- What tables exist?
 SELECT entity_name, module_name, table_name
 FROM Semantic.entity_metadata
@@ -581,10 +807,12 @@ Semantic describes all modules via entity_metadata and table_relationship.
 
 ### 8.1 Required Tables
 
+- data_product_registry (product-level registry in governance database)
 - entity_metadata (~10-50 rows)
 - column_metadata (~100-500 rows)
 - table_relationship (~20-100 rows)
 - naming_standard (~10-30 rows)
+- data_product_map (one row per deployed module)
 
 ### 8.2 Required Views
 
@@ -623,6 +851,8 @@ Every Semantic module must populate the Memory database documentation tables as 
 
 **Decision ID prefix for this module:** `DD-SEMANTIC-{NNN}` (e.g., `DD-SEMANTIC-001`)
 
+**Required product discovery decision:** When the Data Product Orientation Layer is deployed, generate the `DD-DISCOVERY-001` `Design_Decision` INSERT defined in the Memory Module Design Standard. This records why agents and MCP clients read the product manifest before metadata maps or data access.
+
 **Output file placement:** Write documentation capture SQL as the last numbered file in the semantic deployment directory (e.g., `02-semantic/05-documentation.sql`).
 
 **Full protocol, SQL templates, and ID conventions:** See Memory Module Design Standard, Section 8.3 (Workflow 2 — Capture).
@@ -630,6 +860,7 @@ Every Semantic module must populate the Memory database documentation tables as 
 **Design Checklist additions:**
 
 - [ ] `Module_Registry` INSERT generated for this module (with `deployment_status = 'DEPLOYED'`)
+- [ ] `DD-DISCOVERY-001` INSERT generated when the Data Product Orientation Layer is deployed
 - [ ] Min. 3 `Design_Decision` INSERTs generated
 - [ ] `Change_Log` initial release entry generated
 - [ ] Min. 3 `Business_Glossary` terms captured
@@ -684,11 +915,11 @@ A table that appears in `entity_metadata` but has no entries in `table_relations
 
 ## Appendix: Quick Reference
 
-**Core Tables**: entity_metadata, column_metadata, table_relationship, naming_standard, data_product_map
+**Core Tables**: data_product_registry, entity_metadata, column_metadata, table_relationship, naming_standard, data_product_map
 **Required Views**: v_relationship_paths (multi-hop path discovery)
 **Key Principle**: Entity = Table, Attribute = Column
 **Scale**: Hundreds of metadata rows (not millions)
-**Agent Discovery**: Start with data_product_map to find all modules
+**Agent Discovery**: Start with the Data Product Orientation Manifest, use data_product_registry as the backing catalogue, then query data_product_map to find deployed modules
 
 ---
 
@@ -696,6 +927,7 @@ A table that appears in `entity_metadata` but has no entries in `table_relations
 
 | Version | Date | Changes | Author |
 |---------|------|---------|--------|
+| 2.7 | 2026-05-30 | Added `data_product_registry` and the Data Product Orientation Layer as the product-level discovery contract for agents and MCP clients. Clarified that clients should read the product manifest, contract, semantic model, policy, quality, and lineage before querying `data_product_map` for module locations or using approved data access. | Paul Dancer, Worldwide Data Architecture Team, Teradata |
 | 2.6 | 2026-04-15 | Added Section 8.5 `table_relationship` Completeness Requirement: all inter-entity relationships must be registered — intra-module FKs, reference table lookups, cross-module joins, multi-hop semantic joins, and bidirectional traversals. Added path existence and isolation validation queries. Cross-referenced ERD recipe (QC-SEMANTIC-002) as a completeness check. Updated Section 8.4 design checklist with deployment_status requirement, table_relationship completeness check, and v_relationship_paths validation. | Nathan Green, Worldwide Data Architecture Team, Teradata |
 | 2.5 | 2026-03-20 | Fixed boolean column definitions and filter values throughout: converted all CHAR(1) DEFAULT 'Y'/'N' columns (is_active, is_pii, is_sensitive, is_required, is_mandatory) to BYTEINT NOT NULL DEFAULT 1/0; converted all = 'Y' / = 'N' filter values to = 1 / = 0 to align with platform boolean standard. | Nathan Green, Worldwide Data Architecture Team, Teradata |
 | 2.4 | 2026-03-20 | Revised Documentation Capture Requirements section — updated to reflect self-contained data product principle. Documentation tables now reside in the Memory database ({ProductName}_Memory), not a shared dp_documentation database. Removed data_product column from INSERT templates, removed bootstrap checklist item, updated prose references from dp_documentation to Memory database. |

--- a/docs/agent-interaction-lifecycle.html
+++ b/docs/agent-interaction-lifecycle.html
@@ -469,8 +469,10 @@
             <span class="badge badge-semantic">Semantic</span>
             <span class="badge op-read">READ</span>
           </div>
-          <div class="step-db">{Product}_Semantic</div>
+          <div class="step-db">MCP orientation manifest &nbsp;·&nbsp; governance &nbsp;·&nbsp; {Product}_Semantic</div>
           <ul class="step-bullets">
+            <li>Read the MCP product manifest first; the client should discover the product before any tables.</li>
+            <li>Use <code>governance.data_product_registry</code> as the backing catalogue for product contract, metadata surfaces, and approved entrypoint.</li>
             <li>Query <code>{Product}_Semantic.data_product_map</code> to find deployed modules and databases.</li>
             <li>Query <code>{Product}_Semantic.entity_metadata</code> to list all tables and their business purpose.</li>
             <li>Query <code>{Product}_Semantic.table_relationship</code> to learn join patterns and multi-hop paths.</li>

--- a/prompts/Access_Data_Product_Starter.md
+++ b/prompts/Access_Data_Product_Starter.md
@@ -13,7 +13,54 @@ This prompt fragment enables AI agents to discover and navigate AI-Native Data P
 
 You have access to an AI-Native Data Product on Teradata designed for autonomous agent consumption. Follow this discovery protocol to understand the data product structure and generate correct SQL queries.
 
-### Discovery Tier 1: Identify Semantic Module Location
+### Discovery Tier 1: Read the Data Product Orientation Manifest
+
+**Best starting point**: If your environment exposes MCP resources, list products and read the product manifest before deriving database names or querying metadata tables. The manifest tells you where the contract, Semantic model, policy, quality, lineage, physical map, and approved data access surfaces are.
+
+```text
+/resources
+  /products
+  /products/{product_id}/manifest
+  /products/{product_id}/contract
+  /products/{product_id}/semantic
+  /products/{product_id}/lineage
+  /products/{product_id}/quality
+  /products/{product_id}/policy
+  /products/{product_id}/physical-map
+```
+
+Read the manifest first. Follow its `recommended_navigation` order:
+
+1. contract
+2. semantic_model
+3. policy
+4. quality
+5. lineage
+6. data_access
+
+Do not expose or query tables first. Discover the product first, then the contract and meaning, then the approved data path.
+
+**Registry fallback**: If MCP resources are not available, query the product registry before deriving database names. The registry backs the orientation manifest.
+
+```sql
+-- Discover current data product contract and approved entrypoint
+SELECT product_id,
+       product_name,
+       product_version,
+       semantic_database,
+       memory_database,
+       observability_database,
+       approved_entrypoint,
+       approved_access_mode
+FROM governance.data_product_registry
+WHERE is_active = 1
+  AND is_deleted = 0
+  AND product_name = '{DataProductName}';
+```
+
+**Expected result**: Product metadata and the Semantic database name to use in the next tier.
+
+### Discovery Tier 2: Identify Semantic Module Location
 
 **Given**: Data product name (e.g., "Customer360", "FraudDetection")
 
@@ -29,7 +76,7 @@ WHERE DatabaseName LIKE '{DataProductName}_Semantic';
 
 **Expected result**: Database name for Semantic module (e.g., "Customer360_Semantic")
 
-### Discovery Tier 2: Query Module Map
+### Discovery Tier 3: Query Module Map
 
 **Once you know Semantic database location, query the module map**:
 
@@ -55,7 +102,7 @@ ORDER BY module_name;
 - Key tables in each module (entry points)
 - Naming pattern used (separate databases vs single database with prefixes)
 
-### Discovery Tier 3: Explore Schema Metadata
+### Discovery Tier 4: Explore Schema Metadata
 
 **Now you can query Semantic module tables for detailed schema knowledge**:
 
@@ -145,33 +192,45 @@ type belongs in. Never assume co-location or invent database names.
 When starting work on a new data product:
 
 ```sql
--- Step 1: Find Semantic database
--- (Use naming convention: {Product}_Semantic)
+-- Step 1: Discover product contract and approved entrypoint if registry exists
+SELECT product_id, semantic_database, approved_entrypoint, approved_access_mode
+FROM governance.data_product_registry
+WHERE is_active = 1
+  AND is_deleted = 0
+  AND product_name = '{Product}';
 
 -- Step 2: Confirm your agent role exists and is accessible
 SELECT RoleName
 FROM DBC.RoleInfoV
 WHERE RoleName = '{Product}_ROLE_AGENT';
 
--- Step 3: Discover modules
+-- Step 3: If no registry row is available, find Semantic database by convention
+-- (Use naming convention: {Product}_Semantic)
+
+-- Step 4: Discover modules
 SELECT module_name, database_name, primary_tables
 FROM {Product}_Semantic.data_product_map
 WHERE is_active = 1;
 
--- Step 4: Discover entities
+-- Step 5: Discover entities
 SELECT entity_name, table_name, module_name
 FROM {Product}_Semantic.entity_metadata
 WHERE is_active = 1;
 
--- Step 5: Learn relationships
+-- Step 6: Learn relationships
 SELECT relationship_name, source_table, target_table
 FROM {Product}_Semantic.table_relationship
 WHERE is_active = 1;
 
--- Step 6: Ready to generate queries!
+-- Step 7: Ready to generate queries through approved_entrypoint!
 ```
 
 ### Error Handling
+
+**If data_product_registry doesn't exist or has no row for the product**:
+- Fall back to Semantic database discovery by convention
+- Continue with `data_product_map`
+- Prefer the registry when it is later deployed
 
 **If data_product_map doesn't exist**:
 - Data product may not follow AI-Native standards
@@ -188,24 +247,32 @@ WHERE is_active = 1;
 ```sql
 -- Given: Work with "Customer360" data product
 
--- 1. Discover Semantic location
+-- 1. Discover product registry row if available
+SELECT product_id, semantic_database, approved_entrypoint
+FROM governance.data_product_registry
+WHERE is_active = 1
+  AND is_deleted = 0
+  AND product_name = 'Customer360';
+-- Result: semantic_database = Customer360_Semantic
+
+-- 2. Discover Semantic location if registry is not available
 SELECT DatabaseName FROM DBC.DatabasesV 
 WHERE DatabaseName = 'Customer360_Semantic';
 -- Result: Customer360_Semantic exists
 
--- 2. Discover modules
+-- 3. Discover modules
 SELECT module_name, database_name FROM Customer360_Semantic.data_product_map
 WHERE is_active = 1;
 -- Result: Domain → Customer360_Domain
 --         Prediction → Customer360_Prediction
 
--- 3. Discover Domain entities
+-- 4. Discover Domain entities
 SELECT entity_name, table_name FROM Customer360_Semantic.entity_metadata
 WHERE is_active = 1
   AND module_name = 'Domain';
 -- Result: Party → Party_H, Product → Product_H
 
--- 4. Now ready to query
+-- 5. Now ready to query via approved entrypoint
 SELECT p.party_key, p.legal_name
 FROM Customer360_Domain.Party_H p
 WHERE p.is_current = 1;
@@ -216,12 +283,14 @@ WHERE p.is_current = 1;
 **Always start with**:
 1. Know data product name
 2. Confirm `{Product}_ROLE_AGENT` exists and is granted to your service account
-3. Find Semantic module (`{Product}_Semantic`)
-4. Query `data_product_map` for module locations
-5. Query `entity_metadata` for table details
-6. Query `table_relationship` for join patterns
-7. Generate SQL using discovered metadata
-8. If generating DDL: locate the Object Placement Standard before any CREATE statement
+3. Read the MCP product manifest when available
+4. Follow manifest navigation: contract → semantic model → policy → quality → lineage → data access
+5. Query `governance.data_product_registry` if MCP resources are not available
+6. Find Semantic module (`{Product}_Semantic`) if no registry row is available
+7. Query `data_product_map` for module locations
+8. Query `entity_metadata` and `table_relationship` for table details and join patterns
+9. Generate SQL using discovered metadata and the approved entrypoint
+10. If generating DDL: locate the Object Placement Standard before any CREATE statement
 
 This protocol enables fully autonomous navigation of any AI-Native Data Product on Teradata.
 ```

--- a/prompts/Design_Data_Product_Starter.md
+++ b/prompts/Design_Data_Product_Starter.md
@@ -147,7 +147,12 @@ group questions so I am never answering more than 3–4 at a time.
 #### Deliverable 4 — Semantic Module Schema & Seed Data
 
 - DDL for all Semantic tables
+- Data Product Orientation Manifest content:
+  - product id, name, and version
+  - MCP resource entrypoints for manifest, contract, semantic model, lineage, quality, policy, physical map, and approved data access
+  - recommended navigation order: contract → semantic model → policy → quality → lineage → data access
 - Seed `INSERT` statements for this data product:
+  - `data_product_registry` — one current product-level registry row backing the orientation manifest and approved entrypoint
   - `data_product_map` — one row per **deployed** module only (agents use this for discovery; undeployed modules are recorded in Memory — see D5)
   - `entity_metadata` — one row per table across all modules
   - `naming_standard` — full set for this product's conventions
@@ -216,7 +221,7 @@ For each module:
 
 **When designing the Memory module, the following are mandatory in addition to the standard DDL:**
 - `Module_Registry` — one row for **every module considered** during this design (not just deployed ones), with `deployment_status` set to DEPLOYED, PLANNED, or DEPRECATED
-- `Design_Decision` entries for every module that is deferred or excluded (rationale from D1), and for the three mandatory scope decisions: database layout choice (DD-SCOPE-001), module scope rationale (DD-SCOPE-002), and access layer role model (DD-ACCESS-001 — generated in D4.5)
+- `Design_Decision` entries for every module that is deferred or excluded (rationale from D1), and for the mandatory product decisions: database layout choice (DD-SCOPE-001), module scope rationale (DD-SCOPE-002), Data Product Orientation Layer rationale (DD-DISCOVERY-001), and access layer role model (DD-ACCESS-001 — generated in D4.5)
 - `Query_Cookbook` entry `QC-SEMANTIC-002` — the standard ERD generation recipe (template in Memory Module Design Standard Section 8.4)
 - At least one cross-module `Query_Cookbook` entry per deployed module pair
 


### PR DESCRIPTION
## Summary

Adds a Data Product Orientation Layer for AI-native data products.

The core idea is: do not expose "tables first". Expose "product first".

An AI/LLM client should not guess where to start. It should discover the product, read the product manifest, inspect the metadata and governance surfaces, and only then query data through an approved access path.

## Discovery Flow

```text
AI / LLM Client
   ↓
MCP Server
   ↓
1. list data products
2. read data-product manifest
3. read metadata map
4. inspect contracts / semantics / quality / lineage / access rules
5. only then query data
```

## Data Product Discovery Manifest

The first MCP resource should be the product manifest:

```yaml
data_product_id: call_centre.customer_experience
name: Customer Experience Data Product
version: 1.0.0

entrypoints:
  orientation: mcp://products/call_centre/customer_experience/manifest
  contract: mcp://products/call_centre/customer_experience/contract
  semantic_model: mcp://products/call_centre/customer_experience/semantic
  lineage: mcp://products/call_centre/customer_experience/lineage
  quality: mcp://products/call_centre/customer_experience/quality
  policy: mcp://products/call_centre/customer_experience/access-policy
  data_access: mcp://products/call_centre/customer_experience/data

recommended_navigation:
  - contract
  - semantic_model
  - policy
  - quality
  - lineage
  - data_access
```

## MCP Shape

Resources provide context. Tools perform actions.

```text
/resources
  /products
  /products/{product_id}/manifest
  /products/{product_id}/contract
  /products/{product_id}/semantic
  /products/{product_id}/lineage
  /products/{product_id}/quality
  /products/{product_id}/policy
  /products/{product_id}/physical-map

/tools
  search_data_products
  describe_data_product
  get_recommended_entrypoint
  query_product_data
  explain_access_path
```

## Metadata-First Handshake

```text
Client: what products are available?
Server: here are the products and their manifests.

Client: what should I read first?
Server: read contract → semantic model → policy → quality → lineage → physical map.

Client: can I query the data?
Server: yes, through this approved access path.
```

## Why This Matters

This is better than simply publishing schemas because it tells the agent:

- what the product is
- what it means
- what it trusts
- what it may access
- how it should proceed

The `data_product_registry` is the persistent backing catalogue. The manifest is the first MCP-facing orientation resource. `data_product_map` remains useful, but only after the client has discovered the product and read the orientation manifest.

## Native Memory Capture

The rationale is also captured inside the data product itself via required `Memory.Design_Decision` seed `DD-DISCOVERY-001`, so future agents can discover why manifest-first navigation exists without relying on git history or PR context.

## Validation

- Ran `git diff --check`
- Audited the new `governance.data_product_registry` DDL for `COMMENT ON TABLE` and `COMMENT ON COLUMN` coverage
- Reviewed targeted references for `data_product_registry`, `DD-DISCOVERY-001`, and manifest-first discovery wording

No executable test suite was run because this change is standards/docs/prompt content only.
