### PR TITLE
Move data product registry into Semantic module

### DIFF
--- a/design-standards/Memory_Module_Design_Standard.md
+++ b/design-standards/Memory_Module_Design_Standard.md
@@ -1068,7 +1068,7 @@ INSERT INTO Memory.Design_Decision (
     'A manifest-first orientation layer gives clients a safe product-level handshake: discover products, read the manifest, follow recommended navigation, and keep data access behind approved entrypoints backed by policy and quality context.',
     'Agents have a deterministic bootstrap path and do not need to guess where to start. Product owners must maintain the manifest and registry rows, including inactive or deleted products using BYTEINT lifecycle flags.',
     'ACCEPTED', 'ARCHITECTURE',
-    'SEMANTIC', '2.7.0', 'governance.data_product_registry',
+    'SEMANTIC', '2.7.0', '{{DB_SEMANTIC_STD_T}}.data_product_registry',
     'Worldwide Data Architecture Team', CURRENT_DATE,
     CURRENT_DATE, DATE '9999-12-31', 1,
     CURRENT_TIMESTAMP(6), CURRENT_TIMESTAMP(6)

--- a/design-standards/Semantic_Module_Design_Standard.md
+++ b/design-standards/Semantic_Module_Design_Standard.md
@@ -255,7 +255,7 @@ COMMENT ON COLUMN Semantic.naming_standard.created_at IS
 The key principle is **product first, not tables first**. Clients must not start by guessing physical databases or listing tables.
 
 ```sql
-CREATE MULTISET TABLE governance.data_product_registry
+CREATE MULTISET TABLE {{DB_SEMANTIC_STD_T}}.data_product_registry
 (
     product_id             VARCHAR(128) NOT NULL
    ,product_name           VARCHAR(256) NOT NULL
@@ -283,76 +283,76 @@ CREATE MULTISET TABLE governance.data_product_registry
 )
 PRIMARY INDEX (product_id);
 
-COMMENT ON TABLE governance.data_product_registry IS
+COMMENT ON TABLE {{DB_SEMANTIC_STD_T}}.data_product_registry IS
 'Product-level registry - agents and MCP clients discover current data products, metadata contracts, and approved access entrypoints';
 
-COMMENT ON COLUMN governance.data_product_registry.product_id IS
+COMMENT ON COLUMN {{DB_SEMANTIC_STD_T}}.data_product_registry.product_id IS
 'Stable product identifier used by agents, MCP resources, manifests, lineage, policies, and contracts';
 
-COMMENT ON COLUMN governance.data_product_registry.product_name IS
+COMMENT ON COLUMN {{DB_SEMANTIC_STD_T}}.data_product_registry.product_name IS
 'Human-readable data product name';
 
-COMMENT ON COLUMN governance.data_product_registry.product_version IS
+COMMENT ON COLUMN {{DB_SEMANTIC_STD_T}}.data_product_registry.product_version IS
 'Current data product contract or release version';
 
-COMMENT ON COLUMN governance.data_product_registry.product_description IS
+COMMENT ON COLUMN {{DB_SEMANTIC_STD_T}}.data_product_registry.product_description IS
 'Business description of the product purpose, scope, and intended consumers';
 
-COMMENT ON COLUMN governance.data_product_registry.product_status IS
+COMMENT ON COLUMN {{DB_SEMANTIC_STD_T}}.data_product_registry.product_status IS
 'Lifecycle status - DRAFT, ACTIVE, DEPRECATED, or RETIRED';
 
-COMMENT ON COLUMN governance.data_product_registry.owner_team IS
+COMMENT ON COLUMN {{DB_SEMANTIC_STD_T}}.data_product_registry.owner_team IS
 'Owning team or steward responsible for product contract, policy, and support';
 
-COMMENT ON COLUMN governance.data_product_registry.semantic_database IS
-'Semantic module database to query after registry discovery';
+COMMENT ON COLUMN {{DB_SEMANTIC_STD_T}}.data_product_registry.semantic_database IS
+'Semantic module table database that owns the product registry and core Semantic metadata';
 
-COMMENT ON COLUMN governance.data_product_registry.memory_database IS
+COMMENT ON COLUMN {{DB_SEMANTIC_STD_T}}.data_product_registry.memory_database IS
 'Memory module database containing Business_Glossary, Query_Cookbook, and design memory';
 
-COMMENT ON COLUMN governance.data_product_registry.observability_database IS
+COMMENT ON COLUMN {{DB_SEMANTIC_STD_T}}.data_product_registry.observability_database IS
 'Observability module database containing lineage, quality, and usage telemetry where deployed';
 
-COMMENT ON COLUMN governance.data_product_registry.manifest_json IS
+COMMENT ON COLUMN {{DB_SEMANTIC_STD_T}}.data_product_registry.manifest_json IS
 'Machine-readable product orientation manifest for agents and MCP clients';
 
-COMMENT ON COLUMN governance.data_product_registry.contract_uri IS
+COMMENT ON COLUMN {{DB_SEMANTIC_STD_T}}.data_product_registry.contract_uri IS
 'URI for the product contract or external contract document';
 
-COMMENT ON COLUMN governance.data_product_registry.semantic_uri IS
+COMMENT ON COLUMN {{DB_SEMANTIC_STD_T}}.data_product_registry.semantic_uri IS
 'URI for Semantic metadata, an MCP resource, or related documentation';
 
-COMMENT ON COLUMN governance.data_product_registry.quality_uri IS
+COMMENT ON COLUMN {{DB_SEMANTIC_STD_T}}.data_product_registry.quality_uri IS
 'URI for data quality rules, reports, or MCP resource';
 
-COMMENT ON COLUMN governance.data_product_registry.lineage_uri IS
+COMMENT ON COLUMN {{DB_SEMANTIC_STD_T}}.data_product_registry.lineage_uri IS
 'URI for lineage metadata, graph, or MCP resource';
 
-COMMENT ON COLUMN governance.data_product_registry.policy_uri IS
+COMMENT ON COLUMN {{DB_SEMANTIC_STD_T}}.data_product_registry.policy_uri IS
 'URI for policy, usage, classification, or access-control guidance';
 
-COMMENT ON COLUMN governance.data_product_registry.glossary_uri IS
+COMMENT ON COLUMN {{DB_SEMANTIC_STD_T}}.data_product_registry.glossary_uri IS
 'URI for business glossary metadata, typically backed by Memory.Business_Glossary';
 
-COMMENT ON COLUMN governance.data_product_registry.query_cookbook_uri IS
+COMMENT ON COLUMN {{DB_SEMANTIC_STD_T}}.data_product_registry.query_cookbook_uri IS
 'URI for validated query recipes, typically backed by Memory.Query_Cookbook';
 
-COMMENT ON COLUMN governance.data_product_registry.approved_entrypoint IS
+COMMENT ON COLUMN {{DB_SEMANTIC_STD_T}}.data_product_registry.approved_entrypoint IS
 'Approved first data access surface, such as an access view, semantic view, or MCP tool resource';
 
-COMMENT ON COLUMN governance.data_product_registry.approved_access_mode IS
+COMMENT ON COLUMN {{DB_SEMANTIC_STD_T}}.data_product_registry.approved_access_mode IS
 'Approved access mode - VIEW, MCP_TOOL, SEMANTIC_QUERY, or site-defined equivalent';
 
-COMMENT ON COLUMN governance.data_product_registry.is_active IS
+COMMENT ON COLUMN {{DB_SEMANTIC_STD_T}}.data_product_registry.is_active IS
 'Registry row active indicator - 1 = current and discoverable, 0 = inactive';
 
-COMMENT ON COLUMN governance.data_product_registry.is_deleted IS
+COMMENT ON COLUMN {{DB_SEMANTIC_STD_T}}.data_product_registry.is_deleted IS
 'Soft delete indicator - 1 = logically deleted and hidden from discovery, 0 = discoverable when active';
 
-COMMENT ON COLUMN governance.data_product_registry.created_at IS
+COMMENT ON COLUMN {{DB_SEMANTIC_STD_T}}.data_product_registry.created_at IS
 'Timestamp when registry record was created';
 
-COMMENT ON COLUMN governance.data_product_registry.updated_at IS
+COMMENT ON COLUMN {{DB_SEMANTIC_STD_T}}.data_product_registry.updated_at IS
 'Timestamp when registry record was last updated';
 ```
 
@@ -441,7 +441,7 @@ SELECT product_id,
        query_cookbook_uri,
        approved_entrypoint,
        approved_access_mode
-FROM governance.data_product_registry
+FROM {{DB_SEMANTIC_STD_T}}.data_product_registry
 WHERE is_active = 1
   AND is_deleted = 0;
 ```
@@ -773,7 +773,7 @@ QUALIFY ROW_NUMBER() OVER (ORDER BY hop_count) = 1;
 ```sql
 -- Which data products are currently discoverable?
 SELECT product_id, product_name, semantic_database, approved_entrypoint
-FROM governance.data_product_registry
+FROM {{DB_SEMANTIC_STD_T}}.data_product_registry
 WHERE is_active = 1
   AND is_deleted = 0;
 
@@ -807,7 +807,7 @@ Semantic describes all modules via entity_metadata and table_relationship.
 
 ### 8.1 Required Tables
 
-- data_product_registry (product-level registry in governance database)
+- data_product_registry (product-level registry in the Semantic module table database)
 - entity_metadata (~10-50 rows)
 - column_metadata (~100-500 rows)
 - table_relationship (~20-100 rows)

--- a/docs/agent-interaction-lifecycle.html
+++ b/docs/agent-interaction-lifecycle.html
@@ -472,7 +472,7 @@
           <div class="step-db">MCP orientation manifest &nbsp;·&nbsp; governance &nbsp;·&nbsp; {Product}_Semantic</div>
           <ul class="step-bullets">
             <li>Read the MCP product manifest first; the client should discover the product before any tables.</li>
-            <li>Use <code>governance.data_product_registry</code> as the backing catalogue for product contract, metadata surfaces, and approved entrypoint.</li>
+            <li>Use <code>{{DB_SEMANTIC_STD_T}}.data_product_registry</code> as the backing catalogue for product contract, metadata surfaces, and approved entrypoint.</li>
             <li>Query <code>{Product}_Semantic.data_product_map</code> to find deployed modules and databases.</li>
             <li>Query <code>{Product}_Semantic.entity_metadata</code> to list all tables and their business purpose.</li>
             <li>Query <code>{Product}_Semantic.table_relationship</code> to learn join patterns and multi-hop paths.</li>

--- a/prompts/Access_Data_Product_Starter.md
+++ b/prompts/Access_Data_Product_Starter.md
@@ -40,7 +40,7 @@ Read the manifest first. Follow its `recommended_navigation` order:
 
 Do not expose or query tables first. Discover the product first, then the contract and meaning, then the approved data path.
 
-**Registry fallback**: If MCP resources are not available, query the product registry before deriving database names. The registry backs the orientation manifest.
+**Registry fallback**: If MCP resources are not available, use the known Semantic module table database from deployment configuration or standard naming convention, then query the product registry before navigating module metadata or data. The registry backs the orientation manifest and lives in the Semantic module.
 
 ```sql
 -- Discover current data product contract and approved entrypoint
@@ -52,13 +52,13 @@ SELECT product_id,
        observability_database,
        approved_entrypoint,
        approved_access_mode
-FROM governance.data_product_registry
+FROM {SemanticDatabase}.data_product_registry
 WHERE is_active = 1
   AND is_deleted = 0
   AND product_name = '{DataProductName}';
 ```
 
-**Expected result**: Product metadata and the Semantic database name to use in the next tier.
+**Expected result**: Product metadata and the Semantic database name to use for metadata navigation.
 
 ### Discovery Tier 2: Identify Semantic Module Location
 
@@ -194,7 +194,7 @@ When starting work on a new data product:
 ```sql
 -- Step 1: Discover product contract and approved entrypoint if registry exists
 SELECT product_id, semantic_database, approved_entrypoint, approved_access_mode
-FROM governance.data_product_registry
+FROM {SemanticDatabase}.data_product_registry
 WHERE is_active = 1
   AND is_deleted = 0
   AND product_name = '{Product}';
@@ -249,7 +249,7 @@ WHERE is_active = 1;
 
 -- 1. Discover product registry row if available
 SELECT product_id, semantic_database, approved_entrypoint
-FROM governance.data_product_registry
+FROM {SemanticDatabase}.data_product_registry
 WHERE is_active = 1
   AND is_deleted = 0
   AND product_name = 'Customer360';
@@ -285,7 +285,7 @@ WHERE p.is_current = 1;
 2. Confirm `{Product}_ROLE_AGENT` exists and is granted to your service account
 3. Read the MCP product manifest when available
 4. Follow manifest navigation: contract → semantic model → policy → quality → lineage → data access
-5. Query `governance.data_product_registry` if MCP resources are not available
+5. Query `{SemanticDatabase}.data_product_registry` if MCP resources are not available
 6. Find Semantic module (`{Product}_Semantic`) if no registry row is available
 7. Query `data_product_map` for module locations
 8. Query `entity_metadata` and `table_relationship` for table details and join patterns


### PR DESCRIPTION
## Summary
- replace `governance.data_product_registry` with `{{DB_SEMANTIC_STD_T}}.data_product_registry` in the Semantic standard introduced by PR #6
- update registry comments and module lists to describe the registry as part of the Semantic module
- update the Memory design-decision seed and agent lifecycle reference
- update the access prompt fallback to query `{SemanticDatabase}.data_product_registry`

## Rationale
PR #6 added the Data Product Orientation Layer, but it placed the registry in `governance.data_product_registry`. `governance` is not a database defined by the AI-native data product standard. The registry is product orientation metadata and should live inside the Semantic module, alongside `data_product_map` and the other metadata surfaces agents use for discovery.

This keeps the standard self-contained: agents discover the product manifest first, then use the Semantic module registry and metadata map before navigating to data.

## Verification
- `rg` confirmed no remaining `governance.data_product_registry` references in the updated standards, prompts, or lifecycle doc.