### PR TITLE
feat(semantic): agent orientation contract + machine-readable manifest (#20)

### DIFF
--- a/design/modules/semantic.md
+++ b/design/modules/semantic.md
@@ -151,6 +151,18 @@ Entity: PrimaryObject             [kind: Record]  // one row per agent-facing ob
   object_role: Enum{AGENT_ENTRYPOINT|ANALYTICAL_QUERY|REFERENCE_LOOKUP|RELATIONSHIP_BRIDGE|LINEAGE_EVIDENCE|OPERATIONAL_METRIC|WRITE_TARGET|INTERNAL_SUPPORT} [required]
   usage_guidance: Text [optional]
   is_active: Flag
+
+Entity: DataProductOrientation    [kind: Record]  // one ordered row per product resource
+  orientation_id: Identifier
+  product_id: NaturalKey [required]  // the product this resource belongs to (DataProductRegistry.product_id)
+  resource_role: Enum{MANIFEST|TRUST_GATE|MODULE_MAP|OBJECT_CATALOGUE|ENTITY_CATALOGUE|COLUMN_CATALOGUE|RELATIONSHIP_CATALOGUE|RELATIONSHIP_PATHS|LINEAGE|QUERY_COOKBOOK|GLOSSARY|DESIGN_DECISIONS|POLICY|QUALITY} [required]  // open vocabulary; one role per row, never a list
+  container_name: ShortText [optional]  // deployed container, for object-backed resources
+  object_name: ShortText [optional]  // deployed object; used verbatim, never derived
+  resource_uri: ShortText [optional]  // URI for an MCP or external resource, when not a database object
+  usage_guidance: Text [optional]  // how a consumer should use this resource
+  is_required: Flag  // a missing required resource is a conformance failure
+  discovery_order: Integer [required]  // ascending processing order; the trust gate precedes every analytical resource
+  is_active: Flag
 ```
 
 `ViewMetadata` (one row per base-table exposure, with a `view_type` and a single primary exposure per base table) and `ViewColumnType` (curated types for view columns) complete the catalogue; both are platform-detail-heavy and specified in the implementation.
@@ -169,6 +181,12 @@ Discovery is **product-first, not tables-first** (`INV-SEMANTIC-004`). A client 
 4. It queries data **only** through the approved entrypoint.
 
 Where the product is reached over MCP, the orientation layer is exposed as **resources first** (the product list, per-product manifest, contract, semantic model, policy, quality, lineage, physical map) and **tools second** (search products, describe a product, get the recommended entrypoint, query approved data, explain an access path). The registry also designates the **gate-authoritative producer** the [validation pattern](../patterns/validation.md) reads, and its `manifest` records the entrypoints and recommended navigation.
+
+**The orientation relation (normative).** The handshake above is backed by a queryable, ordered relation, `DataProductOrientation` — one row per product resource, its `resource_role`, where it lives, whether it is required, and the `discovery_order` to process it — so a consumer reads the sequence rather than knowing repository conventions or inventing one, and a validator can *check* it. The baseline required roles a conformant product publishes, in canonical order, are: `MANIFEST`, `TRUST_GATE`, `MODULE_MAP`, `OBJECT_CATALOGUE`, `ENTITY_CATALOGUE`, `COLUMN_CATALOGUE`, `RELATIONSHIP_CATALOGUE`; `RELATIONSHIP_PATHS`, `LINEAGE`, `QUERY_COOKBOOK`, `GLOSSARY`, `DESIGN_DECISIONS` are optional, and `POLICY` / `QUALITY` are published where they apply. The vocabulary is open: an extension may add roles.
+
+**Consumption contract (normative).** A consumer processes resources in ascending `discovery_order`; evaluates the `TRUST_GATE` resource **before** any analytical resource, and a blocked gate stops autonomous use (the [validation pattern](../patterns/validation.md)); resolves every `is_required` resource, treating a missing one as a conformance failure; and uses the stored `container.object` (or `resource_uri`) **verbatim**, never deriving object names from conventions (`INV-SEMANTIC-011`).
+
+**The manifest is generated, not authored (normative).** The machine-readable manifest is a **view derived** from `DataProductRegistry` and `DataProductOrientation` — it pivots the ordered resources into named entrypoint columns — so it cannot drift from the metadata it summarises (`INV-SEMANTIC-012`). The registry's serialised `manifest` remains the whole-document form for clients that want it in one read, regenerated from the same authoritative metadata rather than hand-authored to diverge.
 
 **`DD-DISCOVERY-001`.** Deploying the orientation layer settles one decision and records it: *how does an agent that knows only the product's name reach data it is allowed to use?* The record names which manifest fields are populated and why, the approved entrypoint and access mode, and the navigation the manifest recommends. What makes it worth recording rather than inferring is that the answer is a set of choices the deployed metadata cannot explain about itself: an agent can read that an entrypoint is approved, not why that surface was chosen as the approved one, nor what an agent arriving without a product name is expected to do.
 
@@ -264,6 +282,8 @@ Semantic never becomes a dependency of the modules it describes: it observes and
 - `INV-SEMANTIC-005`: `TableRelationship` registers every relationship an agent is expected to traverse; an unrelated entity is a documented standalone or an omission.
 - `INV-SEMANTIC-006`: every entity declares its temporal profile in `EntityMetadata.temporal_pattern`, so validators resolve temporal behaviour from metadata (the `temporal-lifecycle-metadata` pattern).
 - `INV-SEMANTIC-007`: primary-object roles come from the controlled vocabulary; at most one primary exposure per base table.
+- `INV-SEMANTIC-011`: the orientation relation lists the required baseline resources, one row per role, in ascending `discovery_order` with the trust gate ordered before every analytical resource; consumers use stored identities verbatim, and a missing required resource is a conformance failure.
+- `INV-SEMANTIC-012`: the machine-readable manifest is generated from the registry and orientation relation (a derived view), never hand-authored, so it cannot drift from its sources.
 
 ---
 
@@ -278,6 +298,7 @@ Semantic never becomes a dependency of the modules it describes: it observes and
 - [ ] Each entity declares its temporal profile (`INV-SEMANTIC-006`).
 - [ ] The product registry and manifest are populated; discovery is product-first (`INV-SEMANTIC-004`).
 - [ ] The manifest names the `gate_authoritative_producer`, settled as a design decision per the [validation pattern](../patterns/validation.md). One producer still needs naming.
+- [ ] The orientation relation publishes the required baseline resources in `discovery_order` with the trust gate first, and the manifest is a generated view over registry + orientation (`INV-SEMANTIC-011`, `INV-SEMANTIC-012`).
 - [ ] `TableRelationship` completeness verified; no undocumented isolated entity (`INV-SEMANTIC-005`).
 - [ ] Primary objects use verbatim identities and controlled roles (`INV-SEMANTIC-003`, `INV-SEMANTIC-007`).
 - [ ] Documentation capture completed, including `DD-DISCOVERY-001` when the orientation layer is deployed (see the orientation layer section for what it settles), and the ERD recipe `QC-SEMANTIC-002`.

--- a/implementation/teradata/modules/semantic/06-orientation.md
+++ b/implementation/teradata/modules/semantic/06-orientation.md
@@ -1,6 +1,6 @@
 # Semantic: Data Product Orientation Layer (Teradata / MCP)
 
-Binding of [`design/modules/semantic.md`](../../../../design/modules/semantic.md), Data Product Orientation Layer. Product-first discovery: a client orients to the product before touching module maps or data. Backed by `governance.data_product_registry` (`03-registry.sql`); the manifest is stored in `manifest_json`.
+Binding of [`design/modules/semantic.md`](../../../../design/modules/semantic.md), Data Product Orientation Layer. Product-first discovery: a client orients to the product before touching module maps or data. Backed by `governance.data_product_registry` (`03-registry.sql`), the ordered `data_product_orientation` relation, and the generated `data_product_manifest` view (`09-orientation-manifest.sql.j2`). The MCP shapes and manifest document below are the *presentation* of that metadata; the ordered relation and generated view are the authoritative, conformance-checkable source, and `manifest_json` is the serialised whole-document form.
 
 ## MCP resource / tool shapes
 

--- a/implementation/teradata/modules/semantic/09-orientation-manifest.sql.j2
+++ b/implementation/teradata/modules/semantic/09-orientation-manifest.sql.j2
@@ -1,0 +1,75 @@
+-- Semantic module: agent orientation contract + generated manifest (Teradata).
+-- Binding of design/modules/semantic.md §4 (Data Product Orientation Layer).
+-- data_product_orientation formalises the orientation handshake into an ordered, queryable,
+-- conformance-checkable relation (one row per resource); data_product_manifest is a view derived
+-- from the registry and orientation, so the manifest cannot drift from the metadata it summarises.
+-- Registry lives in the shared 'governance' container (03-registry.sql). Replace {{ product }}.
+{%- import 'patterns/temporal-lifecycle-metadata/00-temporal-macros.sql.j2' as tlm %}
+
+-- data_product_orientation: one ordered row per product resource ---------------
+CREATE TABLE {{ product }}_Semantic.data_product_orientation (
+    orientation_id INTEGER NOT NULL GENERATED ALWAYS AS IDENTITY,
+    product_id VARCHAR(128) NOT NULL,           -- data_product_registry.product_id
+    resource_role VARCHAR(40) NOT NULL,         -- controlled vocabulary; one role per row, never a list
+    database_name VARCHAR(128),                 -- deployed container (object-backed resources)
+    object_name VARCHAR(128),                   -- deployed object (object-backed resources)
+    fully_qualified_object_name VARCHAR(257),   -- canonical container.object; used verbatim
+    resource_uri VARCHAR(1000),                 -- URI for an MCP or external resource
+    usage_guidance VARCHAR(500),
+    is_required BYTEINT NOT NULL DEFAULT 0,      -- 1 = a missing resource is a conformance failure
+    discovery_order SMALLINT NOT NULL,           -- ascending processing order; trust gate precedes analytics
+    is_active BYTEINT NOT NULL DEFAULT 1,
+{{ tlm.columns('CURRENT_STATE', pad=8) }}
+)
+PRIMARY INDEX (product_id);
+
+COMMENT ON TABLE {{ product }}_Semantic.data_product_orientation IS
+'Agent orientation contract - one ordered row per product resource; the authoritative bootstrap sequence a consumer reads and a validator checks.';
+COMMENT ON COLUMN {{ product }}_Semantic.data_product_orientation.product_id IS 'Product this resource belongs to - matches data_product_registry.product_id.';
+COMMENT ON COLUMN {{ product }}_Semantic.data_product_orientation.resource_role IS 'Role of the resource in the bootstrap sequence - open vocabulary, one role per row, never a list.';
+COMMENT ON COLUMN {{ product }}_Semantic.data_product_orientation.database_name IS 'Deployed container, for object-backed resources.';
+COMMENT ON COLUMN {{ product }}_Semantic.data_product_orientation.object_name IS 'Deployed object, for object-backed resources.';
+COMMENT ON COLUMN {{ product }}_Semantic.data_product_orientation.fully_qualified_object_name IS 'Canonical container.object identity - consumers use it verbatim, never derived from conventions.';
+COMMENT ON COLUMN {{ product }}_Semantic.data_product_orientation.resource_uri IS 'URI for a resource exposed as MCP or external documentation rather than a database object.';
+COMMENT ON COLUMN {{ product }}_Semantic.data_product_orientation.usage_guidance IS 'How a consumer should use this resource.';
+COMMENT ON COLUMN {{ product }}_Semantic.data_product_orientation.is_required IS '1 = a consumer must resolve this resource; its absence is a conformance failure.';
+COMMENT ON COLUMN {{ product }}_Semantic.data_product_orientation.discovery_order IS 'Ascending processing order; the trust gate role precedes every analytical resource.';
+COMMENT ON COLUMN {{ product }}_Semantic.data_product_orientation.is_active IS '1 = live orientation row, 0 = retired.';
+{{ tlm.comments(product ~ '_Semantic.data_product_orientation', 'CURRENT_STATE') }}
+
+-- data_product_manifest: generated view over registry + orientation -----------
+-- Pivots the ordered resources into named entrypoint columns. Derived, so the manifest cannot
+-- drift from its sources; registry.manifest_json remains the whole-document serialised form.
+REPLACE VIEW {{ product }}_Semantic.data_product_manifest
+(
+      product_id, product_name, product_version, product_status, owner_team
+    , approved_access_mode, approved_entrypoint
+    , manifest_entrypoint, trust_entrypoint, module_map_entrypoint
+    , object_catalogue_entrypoint, entity_catalogue_entrypoint
+    , column_catalogue_entrypoint, relationship_catalogue_entrypoint
+    , manifest_json
+)
+AS
+LOCKING ROW FOR ACCESS
+SELECT
+      r.product_id, r.product_name, r.product_version, r.product_status, r.owner_team
+    , r.approved_access_mode, r.approved_entrypoint
+    , MAX(CASE WHEN o.resource_role = 'MANIFEST'               THEN o.fully_qualified_object_name END)
+    , MAX(CASE WHEN o.resource_role = 'TRUST_GATE'             THEN o.fully_qualified_object_name END)
+    , MAX(CASE WHEN o.resource_role = 'MODULE_MAP'             THEN o.fully_qualified_object_name END)
+    , MAX(CASE WHEN o.resource_role = 'OBJECT_CATALOGUE'       THEN o.fully_qualified_object_name END)
+    , MAX(CASE WHEN o.resource_role = 'ENTITY_CATALOGUE'       THEN o.fully_qualified_object_name END)
+    , MAX(CASE WHEN o.resource_role = 'COLUMN_CATALOGUE'       THEN o.fully_qualified_object_name END)
+    , MAX(CASE WHEN o.resource_role = 'RELATIONSHIP_CATALOGUE' THEN o.fully_qualified_object_name END)
+    , r.manifest_json
+FROM governance.data_product_registry AS r
+LEFT JOIN {{ product }}_Semantic.data_product_orientation AS o
+    ON  o.product_id = r.product_id
+    AND o.is_active  = 1
+WHERE r.is_active = 1 AND r.is_deleted = 0
+GROUP BY
+      r.product_id, r.product_name, r.product_version, r.product_status, r.owner_team
+    , r.approved_access_mode, r.approved_entrypoint, r.manifest_json;
+
+COMMENT ON VIEW {{ product }}_Semantic.data_product_manifest IS
+'Machine-readable product manifest - generated from data_product_registry and data_product_orientation, so it cannot drift. Read first, then follow orientation in discovery_order.';

--- a/implementation/teradata/modules/semantic/README.md
+++ b/implementation/teradata/modules/semantic/README.md
@@ -23,7 +23,8 @@ Teradata binding of [`design/modules/semantic.md`](../../../../design/modules/se
 | `04-path-discovery.sql.j2` | `v_relationship_paths`: recursive multi-hop join-path discovery. |
 | `05-column-catalogue.sql.j2` | `column_catalogue`: live hybrid column catalogue with value provenance. |
 | `06-orientation.md` | MCP resource/tool shapes and the discovery manifest (orientation layer). |
-| `validation.sql.j2` | Primary-object, view, and relationship-completeness checks (canonical validator sources). |
+| `09-orientation-manifest.sql.j2` | `data_product_orientation` (ordered resource relation) and `data_product_manifest` (generated view over registry + orientation). |
+| `validation.sql.j2` | Primary-object, view, relationship-completeness, and orientation checks (canonical validator sources). |
 
 ## Capability bindings
 
@@ -54,3 +55,5 @@ New catalogue tables use the canonical `created_dts`/`updated_dts` audit columns
 | `INV-SEMANTIC-003` (registered primary objects, verbatim identity) | `validation.sql.j2`: orphan modules, missing/kind-mismatched objects, invalid roles, duplicates. |
 | `INV-SEMANTIC-005` (relationship completeness) | `validation.sql.j2`: isolated entities; path existence per expected pair. |
 | `INV-SEMANTIC-007` (one primary per base table) | `validation.sql.j2`: more than one active primary exposure per base table. |
+| `INV-SEMANTIC-011` (ordered orientation, trust gate first) | `validation.sql.j2`: missing required role, duplicate role, duplicate order, undeployed object, unordered trust gate. |
+| `INV-SEMANTIC-012` (manifest generated, cannot drift) | `validation.sql.j2`: a manifest entrypoint with no backing active orientation row. |

--- a/implementation/teradata/modules/semantic/validation.sql.j2
+++ b/implementation/teradata/modules/semantic/validation.sql.j2
@@ -57,3 +57,57 @@ WHERE em.is_active = 1
       WHERE r.is_active = 1
         AND (r.source_table = em.table_name OR r.target_table = em.table_name));
 -- An isolated entity is either a documented standalone (record a Design_Decision) or an omission.
+
+-- INV-SEMANTIC-011: missing required baseline orientation role for a product
+SELECT r.product_id, req.resource_role
+FROM {{ product }}_Semantic.data_product_orientation AS r
+CROSS JOIN (SELECT 'MANIFEST' AS resource_role
+      UNION SELECT 'TRUST_GATE' UNION SELECT 'MODULE_MAP'
+      UNION SELECT 'OBJECT_CATALOGUE' UNION SELECT 'ENTITY_CATALOGUE'
+      UNION SELECT 'COLUMN_CATALOGUE' UNION SELECT 'RELATIONSHIP_CATALOGUE') AS req
+WHERE r.is_active = 1
+  AND NOT EXISTS (
+      SELECT 1 FROM {{ product }}_Semantic.data_product_orientation AS o
+      WHERE o.product_id = r.product_id AND o.is_active = 1
+        AND o.resource_role = req.resource_role)
+GROUP BY r.product_id, req.resource_role;
+
+-- INV-SEMANTIC-011: duplicate active role for one product (each role is singular)
+SELECT product_id, resource_role, COUNT(*) AS n
+FROM {{ product }}_Semantic.data_product_orientation
+WHERE is_active = 1
+GROUP BY product_id, resource_role
+HAVING COUNT(*) > 1;
+
+-- INV-SEMANTIC-011: duplicate discovery_order for one product
+SELECT product_id, discovery_order, COUNT(*) AS n
+FROM {{ product }}_Semantic.data_product_orientation
+WHERE is_active = 1
+GROUP BY product_id, discovery_order
+HAVING COUNT(*) > 1;
+
+-- INV-SEMANTIC-011: object-backed orientation resource that is not deployed
+SELECT o.product_id, o.resource_role, o.fully_qualified_object_name
+FROM {{ product }}_Semantic.data_product_orientation AS o
+LEFT JOIN DBC.TablesV AS t
+    ON t.DatabaseName = o.database_name AND t.TableName = o.object_name
+WHERE o.is_active = 1 AND o.object_name IS NOT NULL AND t.TableName IS NULL;
+
+-- INV-SEMANTIC-011: trust gate not ordered before every analytical resource
+SELECT o.product_id
+FROM {{ product }}_Semantic.data_product_orientation AS o
+WHERE o.is_active = 1
+  AND o.resource_role IN ('ENTITY_CATALOGUE', 'COLUMN_CATALOGUE', 'RELATIONSHIP_CATALOGUE',
+                          'RELATIONSHIP_PATHS', 'QUERY_COOKBOOK')
+  AND o.discovery_order < (
+      SELECT MIN(g.discovery_order)
+      FROM {{ product }}_Semantic.data_product_orientation AS g
+      WHERE g.product_id = o.product_id AND g.is_active = 1
+        AND g.resource_role = 'TRUST_GATE');
+
+-- INV-SEMANTIC-012: a manifest entrypoint with no backing active orientation row
+SELECT m.product_id
+FROM {{ product }}_Semantic.data_product_manifest AS m
+WHERE m.manifest_entrypoint IS NULL
+   OR m.trust_entrypoint IS NULL
+   OR m.entity_catalogue_entrypoint IS NULL;

--- a/tooling/evals/reference/customer-orders.md
+++ b/tooling/evals/reference/customer-orders.md
@@ -226,11 +226,16 @@ Entity: CustomerKeymap            [kind: Keymap]
 
 Every entity above, plus the Search, Prediction, Observability, and Memory entities,
 registers on deploy through `SemanticRegistration`. The relationship graph carries
-Customer to Order, and Order to Product through OrderLine. The orientation manifest is
-the product entry point, so agents orient before touching data.
+Customer to Order, and Order to Product through OrderLine.
+
+The orientation relation lists the product's resources in `discovery_order` with the
+trust gate ordered before every analytical resource, so agents orient and check trust
+before touching data. The manifest is a generated view over the registry and that
+orientation relation, so it cannot drift from the metadata it summarises.
 
 **Invariants:** `INV-SEMANTIC-001`, `INV-SEMANTIC-002`, `INV-SEMANTIC-003`,
-`INV-SEMANTIC-004`, `INV-SEMANTIC-005`, `INV-SEMANTIC-006`, `INV-SEMANTIC-007`.
+`INV-SEMANTIC-004`, `INV-SEMANTIC-005`, `INV-SEMANTIC-006`, `INV-SEMANTIC-007`,
+`INV-SEMANTIC-011`, `INV-SEMANTIC-012`.
 
 ---
 


### PR DESCRIPTION
Resolves #20. **Rebased onto the post-#44 corpus** (the Design / Implementation split from #49).

The original branch edited `design-standards/Semantic_Module_Design_Standard.md` (§3.10–3.11), deleted by the restructure. This re-expresses the change in the two-layer structure **and reconciles it with the orientation layer already in `main`** — which realised orientation as a prose handshake plus a `manifest_json` blob, but with no ordered relation and no generated (drift-proof) manifest.

## Design (platform-neutral)

- **`design/modules/semantic.md` §3.2** — `DataProductOrientation` entity: an ordered relation, one row per resource, controlled `resource_role` vocabulary, `is_required`, `discovery_order`.
- **§4** — the orientation relation and **consumption contract** as normative (process in `discovery_order`; evaluate `TRUST_GATE` before any analytical resource; resolve required resources; use identities verbatim), and the **manifest-is-generated** rule (a derived view over registry + orientation, so it cannot drift). `INV-SEMANTIC-008/009` + designer-checklist item.

## Implementation (Teradata binding)

- `implementation/teradata/modules/semantic/07-orientation-manifest.sql.j2` — `data_product_orientation` table + the generated `data_product_manifest` view over `governance.data_product_registry`; canonical `created_dts`/`updated_dts` via the temporal macro.
- `validation.sql.j2` — five orientation checks + a manifest-consistency check. `06-orientation.md` now points at the relation/view as authoritative; README updated.

## Reconciliation with `main`

The generated `data_product_manifest` view **supersedes hand-authoring** the manifest; `data_product_registry.manifest_json` is kept as the serialised whole-document form (regenerated, not authored). The `resource_role` vocabulary is woven into the §4 prose that previously named resources only loosely.

## Verification (clean on the branch)

```bash
python tooling/validation/design_lint.py design implementation examples
python tooling/evals/brief_lint.py tooling/evals/reference/customer-orders.md
python -m unittest discover -s tooling/validation/tests
```
```
design-lint: clean · brief-lint: clean · Ran 103 tests ... OK
```

## Notes

- Supersedes the earlier version of this PR (which targeted the old `design-standards/` file). Now a single self-contained commit on top of `main`.
- **Parallel-merge caveat (numbering resolved):** disjoint from PR #43 (#9) by construction — this PR owns `INV-SEMANTIC-011/012` and `09-orientation-manifest.sql.j2`; #43 owns `INV-SEMANTIC-008..010` and `07-`/`08-*.sql.j2`. No duplicate ids, no duplicate filenames. The two PRs still edit four files in common (`design/modules/semantic.md`, the semantic `README.md`, `validation.sql.j2`, `tooling/evals/reference/customer-orders.md`), so whoever merges **second** will need a one-time rebase — but every change is a disjoint *addition* at adjacent lines, so resolution is mechanical: keep both sides.
