### PR TITLE
fix(skills): harden verify_skill routing and frontmatter checks

### DIFF
--- a/tooling/skill/verify_skill.py
+++ b/tooling/skill/verify_skill.py
@@ -26,7 +26,7 @@ import argparse
 import re
 import sys
 from pathlib import Path
-from typing import List, NamedTuple
+from typing import Dict, List, NamedTuple, Set
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT / "tooling" / "validation"))
@@ -41,10 +41,8 @@ MAX_SKILL_LINES = 120
 MAX_ROLE_LINES = 150
 MIN_DESCRIPTION_CHARS = 120
 
-PLATFORMS = ("teradata",)
-MODULES = ("domain", "search", "prediction", "observability", "semantic", "memory")
-PATTERNS = ("access-layer", "object-placement", "physical-storage",
-            "temporal-lifecycle-metadata", "validation")
+# The frontmatter is flat by design: exactly these two keys, one line each.
+FRONTMATTER_KEYS = ("name", "description")
 
 # A routed path is a backticked token containing a slash: `design/core/MASTER_DESIGN.md`,
 # `implementation/{platform}/modules/{module}/`. Prose mentions of a directory without
@@ -55,11 +53,13 @@ SECTION_RE = re.compile(r"`([\w./{}-]+\.md)`[^`\n]{0,40}?§(\d+)")
 HEADING_RE = re.compile(r"^##\s+(\d+)\.", re.M)
 SKIP_PREFIXES = ("http://", "https://", "N/A")
 FRONTMATTER_BLOCK_RE = re.compile(r"\A---\r?\n(.*?)\r?\n---\r?\n", re.S)
-# A top-level frontmatter line is a `key:` or a `- ` list item. Anything else at column 0 is
-# a plain scalar that wrapped onto a new line without indentation, which silently truncates
-# the value it belongs to. `design_lint.parse_frontmatter` is a lenient subset parser and
-# accepts it; a real YAML loader - the one the skill installer uses - does not.
-YAML_KEY_RE = re.compile(r"^(?:[A-Za-z_][\w-]*\s*:|-\s)")
+# A top-level frontmatter line is a `key:` at column 0, and the key must be one the flat
+# frontmatter declares. Anything else is a plain scalar that wrapped onto a new line without
+# indentation, which silently truncates the value it belongs to - even when that wrapped
+# fragment happens to open `word:` and so looks like a key. `design_lint.parse_frontmatter`
+# is a lenient subset parser and accepts the wrap; a real YAML loader - the one the skill
+# installer uses - does not.
+YAML_KEY_RE = re.compile(r"^([A-Za-z_][\w-]*)\s*:")
 
 
 class Finding(NamedTuple):
@@ -71,12 +71,32 @@ class Finding(NamedTuple):
         return f"{self.where}: [{self.rule}] {self.message}"
 
 
-def expand(path: str) -> List[str]:
+def discover_placeholders(root: Path) -> Dict[str, List[str]]:
+    """Derive placeholder values from the checkout, never a hardcoded list.
+
+    A new platform, module or pattern added to the corpus must be picked up without
+    editing this file: a route that resolves only under the new value would otherwise be
+    reported as a false `dangling-route`, failing the build on a legitimate change. Values
+    are read from both the design tree (the source of truth) and the implementation tree,
+    because a route may name an area one carries and the other does not.
+    """
+    impl = root / "implementation"
+
+    def impl_children(kind: str) -> Set[str]:
+        return {d.name for d in impl.glob(f"*/{kind}/*") if d.is_dir()}
+
+    platforms = sorted(p.name for p in impl.glob("*") if p.is_dir())
+    modules = sorted({p.stem for p in (root / "design" / "modules").glob("*.md")}
+                     | impl_children("modules"))
+    patterns = sorted({p.stem for p in (root / "design" / "patterns").glob("*.md")}
+                      | impl_children("patterns"))
+    return {"{platform}": platforms, "{module}": modules, "{pattern}": patterns}
+
+
+def expand(path: str, tokens: Dict[str, List[str]]) -> List[str]:
     """Expand the corpus's placeholders into the concrete paths they stand for."""
     out = [path]
-    for token, values in (("{platform}", PLATFORMS),
-                          ("{module}", MODULES),
-                          ("{pattern}", PATTERNS)):
+    for token, values in tokens.items():
         if any(token in p for p in out):
             out = [p.replace(token, v) for p in out for v in values]
     return out
@@ -98,21 +118,27 @@ def check_frontmatter_yaml(root: Path) -> List[Finding]:
     for offset, line in enumerate(m.group(1).splitlines(), start=2):
         if not line.strip():
             continue
-        if not YAML_KEY_RE.match(line):
-            found.append(Finding(
-                "skill-frontmatter", f"SKILL.md:{offset}",
-                f"{line.strip()[:48]!r}... is not a `key: value` at column 0. This "
-                f"frontmatter is flat - `name` and `description`, one line each. A value "
-                f"reflowed onto a second line breaks it: unindented it ends the scalar, and "
-                f"indented it is folded by real YAML but not by the corpus tooling. Keep "
-                f"each value on one line however long it gets."))
+        key = YAML_KEY_RE.match(line)
+        # A wrapped continuation can itself begin `word:` and so parse as a key. Because the
+        # frontmatter is flat, only the known keys are legitimate at column 0; anything else
+        # is a stray line, whether it opens with a colon-word or not.
+        if key and key.group(1) in FRONTMATTER_KEYS:
+            continue
+        found.append(Finding(
+            "skill-frontmatter", f"SKILL.md:{offset}",
+            f"{line.strip()[:48]!r}... is not a `name:` or `description:` line at column 0. "
+            f"This frontmatter is flat - `name` and `description`, one line each. A value "
+            f"reflowed onto a second line breaks it: unindented it ends the scalar, and "
+            f"indented it is folded by real YAML but not by the corpus tooling. Keep "
+            f"each value on one line however long it gets."))
     return found
 
 
 def check_frontmatter(root: Path) -> List[Finding]:
     skill = root / "SKILL.md"
     fm, _ = parse_frontmatter(skill.read_text(encoding="utf-8"))
-    fm = fm or {}
+    if not isinstance(fm, dict):
+        return []  # an absent or unparseable block is already reported by check_frontmatter_yaml
     found = []
 
     def scalar(key: str) -> str:
@@ -175,7 +201,7 @@ def routing_files(root: Path) -> List[Path]:
     return [f for f in files if f.exists()]
 
 
-def check_routes(root: Path) -> List[Finding]:
+def check_routes(root: Path, tokens: Dict[str, List[str]]) -> List[Finding]:
     """Every path the routing names must exist. This is the check that earns its keep."""
     found = []
     for path in routing_files(root):
@@ -184,7 +210,7 @@ def check_routes(root: Path) -> List[Finding]:
         for raw in sorted(set(PATH_RE.findall(text))):
             if raw.startswith(SKIP_PREFIXES):
                 continue
-            candidates = expand(raw)
+            candidates = expand(raw, tokens)
             if not any((root / c.rstrip("/")).exists() for c in candidates):
                 shown = raw if len(candidates) == 1 else f"{raw} (no expansion exists)"
                 found.append(Finding("dangling-route", rel,
@@ -192,14 +218,14 @@ def check_routes(root: Path) -> List[Finding]:
     return found
 
 
-def check_sections(root: Path) -> List[Finding]:
+def check_sections(root: Path, tokens: Dict[str, List[str]]) -> List[Finding]:
     """A `file.md` §N reference must land on a real `## N.` heading in that file."""
     found = []
     for path in routing_files(root):
         rel = path.relative_to(root).as_posix()
         text = path.read_text(encoding="utf-8")
         for raw, number in sorted(set(SECTION_RE.findall(text))):
-            for candidate in expand(raw):
+            for candidate in expand(raw, tokens):
                 target = root / candidate
                 if not target.exists():
                     continue  # already reported by check_routes
@@ -212,13 +238,19 @@ def check_sections(root: Path) -> List[Finding]:
 
 
 def verify(root: Path) -> List[Finding]:
+    # The frontmatter checks read SKILL.md unconditionally; guard here so verify() is safe
+    # to call as a library, not only via main() (which returns exit 2 for the same case).
+    if not (root / "SKILL.md").exists():
+        return [Finding("skill-missing", "SKILL.md",
+                        "no SKILL.md at the root; there is nothing to route from.")]
+    tokens = discover_placeholders(root)
     found = []
     found += check_frontmatter_yaml(root)
     found += check_frontmatter(root)
     found += check_budgets(root)
     found += check_roles_present(root)
-    found += check_routes(root)
-    found += check_sections(root)
+    found += check_routes(root, tokens)
+    found += check_sections(root, tokens)
     return found
 
 

--- a/tooling/validation/tests/test_verify_skill.py
+++ b/tooling/validation/tests/test_verify_skill.py
@@ -159,6 +159,46 @@ class VerifySkillTest(unittest.TestCase):
         self.pkg.write_role("access", "# Access\n\n" + "filler line\n" * 200)
         self.assertIn("too-long", self.pkg.rules())
 
+    def test_placeholder_route_resolves_for_a_discovered_platform(self):
+        """Platform and module names come from the checkout, not a hardcoded list.
+
+        `duckdb` and `graph` are in neither; a route resolving only under them must still
+        pass, or a new platform/module would fail the build the moment it is added.
+        """
+        impl = self.pkg.root / "implementation" / "duckdb" / "modules" / "graph"
+        impl.mkdir(parents=True)
+        (impl / "validation.sql.j2").write_text("SELECT 1;\n", encoding="utf-8")
+        self.pkg.write_role(
+            "build",
+            "# Build\n\nRun `implementation/{platform}/modules/{module}/validation.sql.j2`.\n")
+        self.assertNotIn("dangling-route", self.pkg.rules())
+
+    def test_wrapped_scalar_beginning_with_a_keyword_is_reported(self):
+        """The reflow that a colon-word continuation would otherwise hide.
+
+        A description wrapped onto an unindented line that opens `access:` parses as a
+        stray key, not a `key: value` the flat frontmatter declares, so it must be caught
+        exactly as the plainer wrap is.
+        """
+        (self.pkg.root / "SKILL.md").write_text(
+            "---\nname: ai-native-data-product\n"
+            f"description: {DESCRIPTION}\n"
+            "access: and querying one that already exists\n"
+            "---\n\n# Skill\n",
+            encoding="utf-8")
+        self.assertIn("skill-frontmatter", self.pkg.rules())
+
+    def test_missing_skill_md_is_reported_without_raising(self):
+        """verify() must be safe to call directly, not only behind main()'s guard."""
+        (self.pkg.root / "SKILL.md").unlink()
+        self.assertIn("skill-missing", self.pkg.rules())
+
+    def test_absent_frontmatter_reported_once(self):
+        """One defect, one finding: the block check owns absence, not both checks."""
+        (self.pkg.root / "SKILL.md").write_text("# Skill\n\nNo frontmatter.\n",
+                                                encoding="utf-8")
+        self.assertEqual(self.pkg.rules().count("skill-frontmatter"), 1)
+
 
 class RepositoryIsAConformingSkillTest(unittest.TestCase):
     """The repository itself must pass, so a corpus change cannot silently break routing."""


### PR DESCRIPTION
Follow-up to #55, targeting its `skill-redesign` branch. Four fixes to `tooling/skill/verify_skill.py`, each with a regression test. Full suite green (`Ran 104 tests ... OK (skipped=3)` — the skips are the pre-existing `jinja2`-not-installed cases) and `verify_skill.py` reports the repository conforms.

### 1. Derive `{platform}`/`{module}`/`{pattern}` from the checkout, not a hardcoded list
`PLATFORMS`/`MODULES`/`PATTERNS` were module-level constants. A new platform, module or pattern whose route resolves only under the new value expanded to nothing and was reported as a false `dangling-route`, failing the build on a legitimate corpus change — the exact failure the tool exists to prevent, and a regression from the compiler-era verifier (whose `test_nothing_about_the_standards_is_hardcoded` was removed). `discover_placeholders()` now reads the design and implementation trees.

### 2. Reject a wrapped frontmatter value even when the continuation opens `word:`
`YAML_KEY_RE` accepted any `key:` at column 0, so a `description:` reflowed onto a line beginning e.g. `access:` parsed as a stray key and slipped through — the same install-time defect #55's `02eaa45` fixed, in a form that evaded it. The line's key must now be one the flat frontmatter declares.

### 3. Guard `verify()` against a missing `SKILL.md`
The frontmatter checks read it unconditionally, so a direct caller (tests, or library reuse) got a `FileNotFoundError` instead of a finding; only `main()` checked first. `verify()` now returns a `skill-missing` finding.

### 4. Report an absent frontmatter block once
`check_frontmatter` no longer re-reports absence that `check_frontmatter_yaml` already flags, so one defect yields one finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)