### PR TITLE
feat(validation): evolve the trust gate into a per-area trust map

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Cross-cutting concerns that modules *apply* (referenced, never restated):
 | **[temporal-lifecycle-metadata](design/patterns/temporal-lifecycle-metadata.md)** | Canonical temporal/lifecycle contract; half-open SCD2; point-in-time |
 | **[object-placement](design/patterns/object-placement.md)** | Where objects live and who may reach them (interface spec) |
 | **[physical-storage](design/patterns/physical-storage.md)** | Object-storage layout beneath logical containers (interface spec) |
-| **[validation](design/patterns/validation.md)** | The validation-result contract and the agent stop/go gate |
+| **[validation](design/patterns/validation.md)** | The validation-result contract and the per-area trust map an agent reads before use |
 | **[access-layer](design/patterns/access-layer.md)** | The three roles and phased grants that make a product reachable |
 
 ---

--- a/design/core/GLOSSARY.md
+++ b/design/core/GLOSSARY.md
@@ -83,4 +83,6 @@ Terms used across the design standards. Notation terms (logical types, capabilit
 
 **Temporal data**: Data that tracks change over time, distinguishing *valid time* (when true in reality) from *transaction time* (when recorded). Governed by the [temporal-lifecycle-metadata pattern](../patterns/temporal-lifecycle-metadata.md).
 
+**Trust map**: The per-area picture of what a product's validation has proven: for each area (a module, entity, pattern, or capability), which checks exist, which ran, what they found, and how far the result supports use. It informs rather than permits — no entry withholds use of the product — and it bounds what a failure costs to the area it belongs to. Defined by the [validation pattern](../patterns/validation.md); published by a validator into Observability, and built by hand by a reviewer before one exists.
+
 **Vector store**: A store optimised for holding and searching high-dimensional vectors by similarity. On a given platform it may be a native capability or a specialist component; bound by the `NearestNeighbors` / `ApproxIndex` capabilities.

--- a/design/modules/observability.md
+++ b/design/modules/observability.md
@@ -163,7 +163,7 @@ The lineage entities align with **OpenLineage**: the definition/execution split 
 | `temporal-lifecycle-metadata` | Event entities declare the `EVENT_APPEND_ONLY` profile; `DataLineage` carries an `is_active` lifecycle. |
 | `object-placement` | Which container the tables and views live in, and who may reach them. |
 | `access-layer` | `ROLE_AGENT` write-back (append) to this module: agents record outcomes and quality signals (Phase 2.5). |
-| `validation` | Hosts the validation results; its own quality/lineage evidence is a validator source. |
+| `validation` | Hosts the validation results and the trust map; its own quality/lineage evidence is a validator source. |
 
 ---
 
@@ -178,7 +178,7 @@ Observability is **cross-cutting and soft**: nothing hard-depends on it, and it 
 | `ChangeEventCapture` | Any module recording who changed an entity instance, when, and why: the audit trail that `DEC-COLUMN-STRATEGY` offloads here. |
 | `LineageCapture` | Any module recording the origin of an instance: source system, source record, and producing run. |
 | `QualityScore` | Agents judging fitness before use, and Memory as a learning input. Held as a time series per `DEC-QUALITY-STORAGE`. |
-| Validation results home | The validation pattern, as the container for `validation_run`. |
+| Validation results home | The validation pattern, as the container for `validation_run` and the `validation_area` trust map. |
 | Lineage exposure (definitional + operational) | Agents and dashboards, via the Semantic exposure. |
 
 **Requires:**
@@ -206,7 +206,7 @@ Observability is **cross-cutting and soft**: nothing hard-depends on it, and it 
 - `INV-OBS-002`: change tracking is table-level with aggregate metrics (e.g. `records_affected`), never individual record keys, and **never** before/after business values: capturing changed column *values* (e.g. old/new `legal_name`, `email`) duplicates Domain content into Observability and is a PII / data-privacy defect. The audit trail records *what table changed, when, by whom, and how many rows*: not the data itself; the prior state is reconstructed from Domain's temporal history.
 - `INV-OBS-003`: lineage is split: `DataLineage` declares flows (one row per source → job → target), `LineageRun` records executions (one row per run).
 - `INV-OBS-004`: definitional lineage is retained for the life of the product; execution records follow independent event-retention windows.
-- `INV-OBS-005`: validation results are homed here as append-only evidence (`EVENT_APPEND_ONLY`).
+- `INV-OBS-005`: validation results are homed here as append-only evidence (`EVENT_APPEND_ONLY`), both the run record and the per-area trust map.
 - `INV-OBS-006`: the lineage graph/edge-list consumed by discovery reads active definitions only, so it is stable and deduplicated.
 
 ---

--- a/design/modules/semantic.md
+++ b/design/modules/semantic.md
@@ -155,13 +155,13 @@ Entity: PrimaryObject             [kind: Record]  // one row per agent-facing ob
 Entity: DataProductOrientation    [kind: Record]  // one ordered row per product resource
   orientation_id: Identifier
   product_id: NaturalKey [required]  // the product this resource belongs to (DataProductRegistry.product_id)
-  resource_role: Enum{MANIFEST|TRUST_GATE|MODULE_MAP|OBJECT_CATALOGUE|ENTITY_CATALOGUE|COLUMN_CATALOGUE|RELATIONSHIP_CATALOGUE|RELATIONSHIP_PATHS|LINEAGE|QUERY_COOKBOOK|GLOSSARY|DESIGN_DECISIONS|POLICY|QUALITY} [required]  // open vocabulary; one role per row, never a list
+  resource_role: Enum{MANIFEST|TRUST_MAP|MODULE_MAP|OBJECT_CATALOGUE|ENTITY_CATALOGUE|COLUMN_CATALOGUE|RELATIONSHIP_CATALOGUE|RELATIONSHIP_PATHS|LINEAGE|QUERY_COOKBOOK|GLOSSARY|DESIGN_DECISIONS|POLICY|QUALITY} [required]  // open vocabulary; one role per row, never a list; TRUST_GATE is the legacy spelling of TRUST_MAP
   container_name: ShortText [optional]  // deployed container, for object-backed resources
   object_name: ShortText [optional]  // deployed object; used verbatim, never derived
   resource_uri: ShortText [optional]  // URI for an MCP or external resource, when not a database object
   usage_guidance: Text [optional]  // how a consumer should use this resource
   is_required: Flag  // a missing required resource is a conformance failure
-  discovery_order: Integer [required]  // ascending processing order; the trust gate precedes every analytical resource
+  discovery_order: Integer [required]  // ascending processing order; the trust map precedes every analytical resource
   is_active: Flag
 ```
 
@@ -214,11 +214,11 @@ Discovery is **product-first, not tables-first** (`INV-SEMANTIC-004`). A client 
 3. The manifest recommends navigation: contract → semantic model → policy → quality → lineage → approved data access.
 4. It queries data **only** through the approved entrypoint.
 
-Where the product is reached over MCP, the orientation layer is exposed as **resources first** (the product list, per-product manifest, contract, semantic model, policy, quality, lineage, physical map) and **tools second** (search products, describe a product, get the recommended entrypoint, query approved data, explain an access path). The registry also designates the **gate-authoritative producer** the [validation pattern](../patterns/validation.md) reads, and its `manifest` records the entrypoints and recommended navigation.
+Where the product is reached over MCP, the orientation layer is exposed as **resources first** (the product list, per-product manifest, contract, semantic model, policy, quality, lineage, physical map) and **tools second** (search products, describe a product, get the recommended entrypoint, query approved data, explain an access path). The registry also designates the **trust-authoritative producer** the [validation pattern](../patterns/validation.md) reads, and its `manifest` records the entrypoints and recommended navigation.
 
-**The orientation relation (normative).** The handshake above is backed by a queryable, ordered relation, `DataProductOrientation` — one row per product resource, its `resource_role`, where it lives, whether it is required, and the `discovery_order` to process it — so a consumer reads the sequence rather than knowing repository conventions or inventing one, and a validator can *check* it. The baseline required roles a conformant product publishes, in canonical order, are: `MANIFEST`, `TRUST_GATE`, `MODULE_MAP`, `OBJECT_CATALOGUE`, `ENTITY_CATALOGUE`, `COLUMN_CATALOGUE`, `RELATIONSHIP_CATALOGUE`; `RELATIONSHIP_PATHS`, `LINEAGE`, `QUERY_COOKBOOK`, `GLOSSARY`, `DESIGN_DECISIONS` are optional, and `POLICY` / `QUALITY` are published where they apply. The vocabulary is open: an extension may add roles.
+**The orientation relation (normative).** The handshake above is backed by a queryable, ordered relation, `DataProductOrientation` — one row per product resource, its `resource_role`, where it lives, whether it is required, and the `discovery_order` to process it — so a consumer reads the sequence rather than knowing repository conventions or inventing one, and a validator can *check* it. The baseline required roles a conformant product publishes, in canonical order, are: `MANIFEST`, `TRUST_MAP`, `MODULE_MAP`, `OBJECT_CATALOGUE`, `ENTITY_CATALOGUE`, `COLUMN_CATALOGUE`, `RELATIONSHIP_CATALOGUE`; `RELATIONSHIP_PATHS`, `LINEAGE`, `QUERY_COOKBOOK`, `GLOSSARY`, `DESIGN_DECISIONS` are optional, and `POLICY` / `QUALITY` are published where they apply. The vocabulary is open: an extension may add roles.
 
-**Consumption contract (normative).** A consumer processes resources in ascending `discovery_order`; evaluates the `TRUST_GATE` resource **before** any analytical resource, and a blocked gate stops autonomous use (the [validation pattern](../patterns/validation.md)); resolves every `is_required` resource, treating a missing one as a conformance failure; and uses the stored `container.object` (or `resource_uri`) **verbatim**, never deriving object names from conventions (`INV-SEMANTIC-011`).
+**Consumption contract (normative).** A consumer processes resources in ascending `discovery_order`; reads the `TRUST_MAP` resource **before** any analytical resource, and carries the confidence it found there into what it reports (the [validation pattern](../patterns/validation.md)); resolves every `is_required` resource, treating a missing one as a conformance failure; and uses the stored `container.object` (or `resource_uri`) **verbatim**, never deriving object names from conventions (`INV-SEMANTIC-011`).
 
 **The manifest is generated, not authored (normative).** The machine-readable manifest is a **view derived** from `DataProductRegistry` and `DataProductOrientation` — it pivots the ordered resources into named entrypoint columns — so it cannot drift from the metadata it summarises (`INV-SEMANTIC-012`). The registry's serialised `manifest` remains the whole-document form for clients that want it in one read, regenerated from the same authoritative metadata rather than hand-authored to diverge.
 
@@ -323,14 +323,14 @@ Semantic never becomes a dependency of the modules it describes: it observes and
 - `INV-SEMANTIC-008`: a consumer resolves the object to query through `AccessObject` (an agent-consumable object), never by inferring an object's role, layer, or entity from its name; the registry is the single source of truth and is established once at deployment from verifiable structure.
 - `INV-SEMANTIC-009`: every `AccessObject.represents_entity` and every `AccessComposition.member_entity` resolves to a catalogued `EntityMetadata` entity; a non-`COMPOSITE` consumable object names the entity it represents.
 - `INV-SEMANTIC-010`: a `COMPOSITE` object's structure is recorded in `AccessComposition` with exactly one `ANCHOR` member, and is expanded as a unit from that metadata, never by parsing the object's definition.
-- `INV-SEMANTIC-011`: the orientation relation lists the required baseline resources, one row per role, in ascending `discovery_order` with the trust gate ordered before every analytical resource; consumers use stored identities verbatim, and a missing required resource is a conformance failure.
+- `INV-SEMANTIC-011`: the orientation relation lists the required baseline resources, one row per role, in ascending `discovery_order` with the trust map ordered before every analytical resource; consumers use stored identities verbatim, and a missing required resource is a conformance failure.
 - `INV-SEMANTIC-012`: the machine-readable manifest is generated from the registry and orientation relation (a derived view), never hand-authored, so it cannot drift from its sources.
 
 ---
 
 ## 11. Designer Responsibilities
 
-**Designers supply:** the entity/column/relationship catalogue for every module; naming standards; the module map and primary objects with their roles; the product registry and manifest, including the gate-authoritative producer the [validation pattern](../patterns/validation.md) reads; the temporal profile per entity.
+**Designers supply:** the entity/column/relationship catalogue for every module; naming standards; the module map and primary objects with their roles; the product registry and manifest, including the trust-authoritative producer the [validation pattern](../patterns/validation.md) reads; the temporal profile per entity.
 
 **Design review checklist:**
 
@@ -338,8 +338,8 @@ Semantic never becomes a dependency of the modules it describes: it observes and
 - [ ] Entities, columns, relationships, and primary objects registered for every deployed module (`SemanticRegistration`).
 - [ ] Each entity declares its temporal profile (`INV-SEMANTIC-006`).
 - [ ] The product registry and manifest are populated; discovery is product-first (`INV-SEMANTIC-004`).
-- [ ] The manifest names the `gate_authoritative_producer`, settled as a design decision per the [validation pattern](../patterns/validation.md). One producer still needs naming.
-- [ ] The orientation relation publishes the required baseline resources in `discovery_order` with the trust gate first, and the manifest is a generated view over registry + orientation (`INV-SEMANTIC-011`, `INV-SEMANTIC-012`).
+- [ ] The manifest names the `trust_authoritative_producer`, settled as a design decision per the [validation pattern](../patterns/validation.md). One producer still needs naming.
+- [ ] The orientation relation publishes the required baseline resources in `discovery_order` with the trust map first, and the manifest is a generated view over registry + orientation (`INV-SEMANTIC-011`, `INV-SEMANTIC-012`).
 - [ ] `TableRelationship` completeness verified; no undocumented isolated entity (`INV-SEMANTIC-005`).
 - [ ] Primary objects use verbatim identities and controlled roles (`INV-SEMANTIC-003`, `INV-SEMANTIC-007`).
 - [ ] Consumable objects registered in `AccessObject` and composites recorded in `AccessComposition`; consumers resolve through the registry, not object names (`INV-SEMANTIC-008` to `INV-SEMANTIC-010`).

--- a/design/patterns/temporal-lifecycle-metadata.md
+++ b/design/patterns/temporal-lifecycle-metadata.md
@@ -219,7 +219,7 @@ The pattern defines two exposure **surfaces** per consumable entity. How each is
 
 ## 10. Conformance Rules
 
-Lifted directly into validator profiles by the [validation pattern](validation.md). Rules marked **[B]** are blocking (agent stop/go); the rest default to warning severity.
+Lifted directly into validator profiles by the [validation pattern](validation.md), scoped to this pattern's area or to the entity a data check resolves. Rules marked **[B]** carry CRITICAL/ERROR severity, which takes the area they fail in to `weak` confidence; the rest default to warning severity.
 
 | Rule | Check |
 |------|-------|
@@ -256,7 +256,7 @@ Lifted directly into validator profiles by the [validation pattern](validation.m
 
 ## 12. Relationship to Other Standards
 
-- **[Validation pattern](validation.md)**: rules are written to lift directly into validator profiles; blocking rules gate agent use.
+- **[Validation pattern](validation.md)**: rules are written to lift directly into validator profiles; a `[B]` rule failing takes its area to `weak` confidence on the published trust map.
 - **[Object-placement pattern](object-placement.md)**: layer *naming* is owned by object placement; defines layer *responsibilities* only.
 - **[Access-layer pattern](access-layer.md)**: realises the surfaces as concrete access objects.
 - **[Semantic module](../modules/semantic.md)**: its entity metadata carries the profile declaration; its own catalogue tables follow the current-state or SCD2 profile.

--- a/design/patterns/validation.md
+++ b/design/patterns/validation.md
@@ -3,7 +3,7 @@ title: Validation Pattern
 anchor: validation
 type: pattern
 status: standard
-version: 2.0
+version: 2.1
 normative: true
 ---
 
@@ -19,25 +19,26 @@ normative: true
 |-----------|-------|
 | **Status** | STANDARD |
 | **Type** | Pattern (cross-cutting, platform-agnostic) |
-| **Scope** | Machine-readable validation results and the agent stop/go gate for every product |
+| **Scope** | Machine-readable validation results and the per-area trust map every product publishes |
 | **Extends** | [Master Design](../core/MASTER_DESIGN.md) |
 | **Module home** | [Observability](../modules/observability.md): validation results are operational evidence |
 | **Notation** | [Design Language](../core/DESIGN_LANGUAGE.md) |
-| **Wire schema** | 2.0 (canonical); 1.0 registered as a legacy binding |
+| **Wire schema** | 2.1 (canonical, additive over 2.0); 1.0 registered as a legacy binding |
 | **Implementations** | [`implementation/teradata/patterns/validation/`](../../implementation/teradata/patterns/validation/) |
 
-This pattern defines the **validation result contract** and the **gate** an agent evaluates before using a product. Each module and pattern contributes *conformance checks*, its invariants, the temporal `TLM-01..17` rules, the Semantic primary-object validations, which validators execute and publish as results in this contract. Results are append-only operational evidence in the Observability module (temporal profile `EVENT_APPEND_ONLY`).
+This pattern defines the **validation result contract** and the **trust map** an agent reads before using a product. Each module and pattern contributes *conformance checks*, its invariants, the temporal `TLM-01..17` rules, the Semantic primary-object validations, which validators execute and publish as results in this contract. Results are append-only operational evidence in the Observability module (temporal profile `EVENT_APPEND_ONLY`).
 
 ---
 
 ## 1. Purpose and Principles
 
-An agent needs a published validation *result* and an explicit gate to evaluate a product before querying it. This pattern defines both.
+An agent needs published validation *evidence*, resolved per area, so it can judge how far to trust the part of the product it is about to use. This pattern defines that evidence and how to read it.
 
 1. **One results contract, many producers.** A unit-test harness, a simple validator, or a full trust engine all publish the same record shape, distinguished by `producer_id`.
 2. **Only a validator computes trust.** Consumers are read-only: they act on published results and never re-derive a verdict from raw evidence.
-3. **The stop/go decision is authoritative and singular.** Each product designates one gate-authoritative producer; its latest `agent_use_allowed` is a decision, not advice. Critical failures block use regardless of any score.
-4. **Validation results are operational evidence**: append-only event records in Observability.
+3. **The map informs; it does not block.** Trust is published per area, and no value in this contract withholds permission to use the product. A consumer proceeds and **discloses**: it states the confidence and the open gaps for every area it used. What a failure costs is bounded by the area it belongs to, so a defect in one module no longer withdraws a product an agent needed for another.
+4. **Coverage is part of the answer.** An area no check reached is *unknown*, never *fine*. The map records which checks existed, which ran, and what would raise confidence, so an agent can say how far it trusts an answer and a product owner can see what to build next.
+5. **Validation results are operational evidence**: append-only event records in Observability.
 
 ---
 
@@ -47,7 +48,7 @@ An agent needs a published validation *result* and an explicit gate to evaluate 
 
 | Capability | Made available to |
 |------------|-------------------|
-| `QualityScore` | Agents and reviewers, as the readiness scores and status vocabulary this pattern defines over validation evidence. |
+| `QualityScore` | Agents and reviewers, as the per-area trust map, the readiness scores, and the status vocabularies this pattern defines over validation evidence. |
 
 **Requires:**
 
@@ -59,53 +60,121 @@ An agent needs a published validation *result* and an explicit gate to evaluate 
 
 ## 3. The Validation Result
 
-The result entity is **`ValidationRun`**, bound to `validation_run`. The name is part of the contract, not a designer's choice: the standard conformance queries and the gate projection resolve it by name, so a product that names it something else does not fail loudly. The queries find no rows, count no failures, and report clean. A design brief that proposes a different name is corrected rather than accommodated.
+Two related records: one **run** record summarising the whole run, and one **area** record for each area the run covers. Both are append-only, and both bind their physical types per implementation.
 
-One logical record per product per producer per run; consumers read the **latest** per (product, producer). Physical types bind per implementation.
+### 3.1 The run record
+
+The result entity is **`ValidationRun`**, bound to `validation_run`. The name is part of the contract, not a designer's choice: the standard conformance queries and the latest-run projection resolve it by name, so a product that names it something else does not fail loudly. The queries find no rows, count no failures, and report clean. A design brief that proposes a different name is corrected rather than accommodated.
+
+One logical record per product per producer per run; consumers read the **latest** per (product, producer).
 
 | Field | Meaning |
 |-------|---------|
 | `product_prefix` | Product identity the run evaluated |
 | `producer_id`, `producer_version` | Identity and version of the producing validator/harness |
-| `profile_id`, `profile_version` | Decision/check profile evaluated (nullable for simple harnesses) |
+| `profile_id`, `profile_version` | Check profile evaluated: which checks it defines, and their scopes (nullable for simple harnesses) |
 | `source_format` | Provenance: `NATIVE`, or the interchange format it was ingested from |
 | `payload_schema_version` | Wire schema version of this record |
 | `run_id` | Deterministic run identifier |
 | `started_dts`, `completed_dts` | Run instants (typed timestamps, persisted UTC) |
-| `trust_status` | `TRUSTED` \| `DEGRADED` \| `UNTRUSTED` |
-| `agent_use_allowed` | Stop/go decision: go / stop |
+| `trust_status` | Advisory product-level summary of the map: `TRUSTED` \| `DEGRADED` \| `UNTRUSTED` |
+| `agent_use_allowed` | **Deprecated at schema 2.1**: retained for wire compatibility, no longer a decision (§4.4) |
 | `total_checks`, `passed_count`, `failed_count`, `error_count` | Check totals by **status** |
-| `critical_failure_count`, `error_failure_count` | Gate counts by **severity** among failed/errored checks |
+| `critical_failure_count`, `error_failure_count` | Counts by **severity** among failed/errored checks |
 | `data_product_trust_score` | Conformance score, 0-100 or null |
 | `performance_readiness_score`, `operational_readiness_score` | Other score dimensions, 0-100 or null |
 | `repair_candidate_count` | True (uncapped) number of repair candidates |
 | `failed_checks_json` | Machine-readable failure detail, capped |
 | `repair_candidates_json` | Machine-readable repair proposals, capped |
-| `evidence_expires_dts` | Producer-declared expiry of this evidence (nullable;) |
+| `evidence_expires_dts` | Producer-declared expiry of this evidence (nullable) |
 
 A simple test harness populates the identity, status, and count fields and leaves scores, JSON blobs, and profile fields null: a fully conformant result. Runs are **appended**, never overwritten.
 
+### 3.2 The area record
+
+The trust-map entity is **`ValidationArea`**, bound to `validation_area`. One logical record per run per area; consumers read the **latest** per (product, producer, area). Its name is part of the contract for the same reason `validation_run` is.
+
+| Field | Meaning |
+|-------|---------|
+| `product_prefix`, `producer_id`, `run_id` | Parentage: the run this entry belongs to |
+| `scope_kind`, `scope_id` | The area this entry describes (§4.1) |
+| `checks_expected` | How many checks the profile defines for this area; `0` means none is defined |
+| `checks_ran` | How many of them executed in this run |
+| `passed_count`, `failed_count`, `error_count` | Check outcomes within the area, by **status** |
+| `critical_failure_count`, `error_failure_count` | Counts by **severity** among the area's failed/errored checks |
+| `area_status` | `pass` \| `fail` \| `partial` \| `not-validated` \| `no-evidence` (§4.3) |
+| `confidence` | `strong` \| `partial` \| `weak` \| `unknown` (§4.3) |
+| `open_gaps` | What is uncovered or unproven here; required unless `confidence` is `strong` |
+| `recommended_action` | What would raise confidence in this area; required unless `confidence` is `strong` |
+| `completed_dts` | Inherited from the run, so the latest-per-area projection is deterministic |
+
+Coverage is `checks_ran / checks_expected`. It is **derived on read**, not stored, so there is no second copy of it to drift from the counts.
+
+A run publishes an entry for **every area its profile covers, including the areas it could not check**. An area left out of the map is invisible, and an invisible area reads as an area with nothing wrong: the opposite of what this pattern is for.
+
+A producer that publishes no area records is at wire schema 2.0. Consumers read its run record as a single `PRODUCT`-scope entry (§10), so the map has one shape everywhere.
+
 ---
 
-## 4. Status Vocabulary and Decision Semantics
+## 4. Status Vocabularies and Trust Semantics
 
-`trust_status` has exactly three values: **`TRUSTED`**, **`DEGRADED`**, **`UNTRUSTED`**.
+### 4.1 The area
 
-**Default decision profile** (rules in order):
+An **area** is the unit the map resolves trust to. Its key is (`scope_kind`, `scope_id`):
+
+| `scope_kind` | `scope_id` is | Example |
+|--------------|---------------|---------|
+| `MODULE` | The module anchor | `domain` |
+| `ENTITY` | The catalogued entity, qualified by its module anchor | `domain.Ticket` |
+| `PATTERN` | The pattern anchor | `temporal-lifecycle-metadata` |
+| `CAPABILITY` | The capability name from the catalogue | `NearestNeighbors` |
+| `PRODUCT` | The product prefix: whole-product entries that belong to no narrower area | `CALLCENTRE` |
+
+Identities come from the corpus and the product's own Semantic catalogue, never from a convention applied to an object name. Areas may overlap by design: an `ENTITY` entry says something narrower than the `MODULE` entry above it, and a consumer reading both takes the narrowest entry that covers what it is about to query.
+
+### 4.2 Coverage
+
+Coverage separates *proven sound* from *never looked at*, which a pass rate alone cannot express. `checks_expected` is what the producer's profile defines for the area; `checks_ran` is what executed. An area whose only check is unwritten reports `checks_expected = 0`, which is `no-evidence`: an honest statement that nothing is known, and a coverage gap for the product owner to close.
+
+### 4.3 Area status and confidence
+
+**`area_status`** — what happened to this area in this run:
+
+| Condition | `area_status` |
+|-----------|---------------|
+| `checks_expected = 0` | `no-evidence` |
+| Checks defined, `checks_ran = 0` | `not-validated` |
+| Checks ran, no failures, `checks_ran = checks_expected` | `pass` |
+| Checks ran, no failures, `checks_ran < checks_expected` | `partial` |
+| Any failed or errored check in the area | `fail` |
+
+**`confidence`** — how far the entry supports use of the area, severity-weighted and coverage-aware:
+
+| Condition | `confidence` |
+|-----------|--------------|
+| Nothing ran (`no-evidence` or `not-validated`) | `unknown` |
+| Any CRITICAL or ERROR-severity failure in the area, or coverage below half | `weak` |
+| Failures only at WARNING/INFO severity, or full pass on partial coverage | `partial` |
+| Every defined check ran and passed | `strong` |
+
+Rules apply in order, first match wins. The vocabulary is deliberately the reviewer's (`roles/review.md`): a review that becomes a deployed product's first published map should not have to be retyped in a different language.
+
+An area at `weak` or `unknown` is **not** an area an agent may not use. It is an area an agent must be honest about when it uses it (§9).
+
+### 4.4 The product-level summary
+
+`trust_status` has exactly three values: **`TRUSTED`**, **`DEGRADED`**, **`UNTRUSTED`**. It is an **advisory summary** of the map, useful for a dashboard or a first glance, and it is not permission and not a decision. A consumer that needs to know whether to rely on something reads the entries for the areas it is about to use.
+
+**Default summary profile** (rules in order):
 
 1. Any execution error (`error_count > 0`), any CRITICAL-severity failure, or any ERROR-severity failure → `UNTRUSTED`. **No score can rescue this rule.**
 2. Else `data_product_trust_score < 70` → `UNTRUSTED`.
 3. Else any failed check, or `data_product_trust_score < 90` → `DEGRADED`.
 4. Else → `TRUSTED`.
 
-Producers that compute no scores skip the score clauses. `agent_use_allowed` derives purely from status:
+Producers that compute no scores skip the score clauses. Implementation profiles may **tighten** the summary toward caution but never loosen it.
 
-```text
-agent_use_allowed = go    when trust_status IN (TRUSTED, DEGRADED)
-agent_use_allowed = stop  when trust_status = UNTRUSTED
-```
-
-Implementation profiles may **tighten** the default profile but never loosen it. Consumers must not silently override a blocked status; overrides are logged human decisions, outside this contract.
+**`agent_use_allowed` is deprecated at schema 2.1.** The field remains so a 2.0 reader still parses a 2.1 record, and a 2.1 producer publishes go in it. It carries no authority at any schema version, and a consumer must not branch on it: an area that needs disclosure gets disclosure, and nothing in this contract withholds use. Consumers reading 1.0 or 2.0 records ignore the field for the same reason.
 
 ---
 
@@ -123,7 +192,7 @@ Two independent axes:
 | `error_failure_count` | Failed/errored checks with **severity** `ERROR` |
 | `failed_count` | Checks with status `FAILED`, any severity |
 
-`WARNING`/`INFO` failures feed `failed_count` but not the gate counts: they can produce `DEGRADED`, never `UNTRUSTED`. Producers whose native format carries no severity default failed checks to `ERROR`. The three gate counts are **authoritative**; the JSON blobs are capped and must never be counted by consumers.
+Both axes are counted twice over: once for the whole run on the run record, and once per area on that area's entry. `WARNING`/`INFO` failures feed `failed_count` but not the severity counts: they can hold an area at `partial` confidence, never drive it to `weak`. Producers whose native format carries no severity default failed checks to `ERROR`. The counts are **authoritative**; the JSON blobs are capped and must never be counted by consumers.
 
 ---
 
@@ -137,7 +206,7 @@ Scores are **optional**: null means *not assessed*, never *perfect*. Where compu
 | `performance_readiness_score` | PERFORMANCE |
 | `operational_readiness_score` | OPERATIONAL |
 
-Only `data_product_trust_score` participates in the default profile's thresholds. The three scores are reported separately and must not be blended.
+Only `data_product_trust_score` participates in the default summary profile's thresholds. The three scores are reported separately and must not be blended. A score is a run-level figure: it summarises, it does not locate, which is what the map is for.
 
 ---
 
@@ -152,6 +221,8 @@ Only `data_product_trust_score` participates in the default profile's thresholds
   "category": "SEMANTIC",
   "severity": "CRITICAL",
   "status": "FAILED",
+  "scope_kind": "MODULE",
+  "scope_id": "semantic",
   "row_count": 39,
   "sample_rows": [
     {
@@ -166,7 +237,7 @@ Only `data_product_trust_score` participates in the default profile's thresholds
 }
 ```
 
-Rules: the check-level identifier is **`test_id`** (`issue_code` exists only inside `sample_rows`); every `sample_rows` element carries `issue_code`, `repair_hint`, and the object-identifying keys; `row_count` is the **true** total, `sample_rows` the first ≤ 3: consumers render the remainder as `+ (row_count − shown) more`, never by counting the blob; `error_message` is non-null only for status `ERROR`; every issue code is catalogued in the producer's documentation; the blob is optional for count-only producers.
+Rules: the check-level identifier is **`test_id`** (`issue_code` exists only inside `sample_rows`); `scope_kind` / `scope_id` name the area the check belongs to (§4.1, §12), so a consumer reading a failure knows which map entry it landed on; every `sample_rows` element carries `issue_code`, `repair_hint`, and the object-identifying keys; `row_count` is the **true** total, `sample_rows` the first ≤ 3: consumers render the remainder as `+ (row_count − shown) more`, never by counting the blob; `error_message` is non-null only for status `ERROR`; every issue code is catalogued in the producer's documentation; the blob is optional for count-only producers.
 
 ---
 
@@ -189,34 +260,49 @@ Rules: the check-level identifier is **`test_id`** (`issue_code` exists only ins
 
 ---
 
-## 9. Consumption Contract and Gate Authority
+## 9. Consumption Contract and Trust Authority
 
-**Gate authority.** Multiple producers may publish for one product; the decision stays singular. Each product **designates exactly one gate-authoritative producer** in its orientation metadata. The product-level gate is that producer's latest `agent_use_allowed` / `trust_status`. Other producers' results are **evidence**: surfaced (especially disagreements) but not gate-moving. Absent a designation, consumers apply the conservative composite: blocked if **any** producer's latest blocks.
+**Read, select, proceed, disclose.** A consumer works through the map in four steps:
+
+1. **Read** the map **before** analytical use, discovering its location and the authoritative producer through product orientation.
+2. **Select** the entries covering the areas the work will touch: the modules, entities, patterns, and capabilities the query plan reaches, taking the narrowest entry that covers each. Areas the work does not touch place no constraint on it.
+3. **Proceed.** Nothing in this contract withholds use, at any confidence.
+4. **Disclose, proportionally.** State the confidence for every area used. An area at `weak`, or any CRITICAL/ERROR failure in an area used, is surfaced with its consequence and its `recommended_action`. An area at `unknown` is reported as unknown: never as sound, never silently. An answer drawn only from `strong` areas says that too, because the consumer has earned the right to say it.
+
+**Trust authority.** Multiple producers may publish for one product. Each product **designates exactly one trust-authoritative producer** in its orientation metadata; that producer's latest entries are *the* map. Other producers' results are **evidence**: surfaced, especially where they disagree, but not map-defining. Absent a designation, consumers take the most cautious entry per area across producers and say that they did so, because a product with two maps and no designation has not told anyone which one it means.
 
 **The designation is made at design time.** Everything above is written from the consumer's side, and a consumer can only read a designation that already exists. VAL-13 is checked at runtime; the fact it checks has to be established while the product is being designed, because by deploy time the manifest is already written. So it is a designer's obligation, stated here rather than left to be inferred from the consumer rule:
 
-> Name the producer whose `agent_use_allowed` verdict is the product's formal gate. Record it as a design decision, and carry it into the orientation manifest as `gate_authoritative_producer` (the [Semantic module](../modules/semantic.md) owns the field). Where the product has exactly one producer it is gate-authoritative by definition, and must still be named: an implicit designation is not readable.
+> Name the producer whose trust map is the product's authoritative one. Record it as a design decision, and carry it into the orientation manifest as `trust_authoritative_producer` (the [Semantic module](../modules/semantic.md) owns the field; `gate_authoritative_producer` is the legacy spelling and readers still honour it). Where the product has exactly one producer it is authoritative by definition, and must still be named: an implicit designation is not readable.
 
-A product that reaches deployment with a results table, a validator, and no designation has no gate. It has opinions, and the conservative composite applies to them, which is rarely what the designer intended and never what they wrote down.
+**Further consumer rules.** Never re-derive a status or a confidence, and never recount capped blobs: only a validator computes trust. Treat unknown JSON keys as additive extension (ignore, don't fail). Apply the staleness rules (§11).
 
-**Consumer rules.** Read the gate **before** analytical use (discovering its location and the designated producer through product orientation); `agent_use_allowed = stop` (or `UNTRUSTED`) is a stop signal for autonomous use with no silent override; `DEGRADED` permits use but the degradation is surfaced; never re-derive verdicts or recount capped blobs; treat unknown JSON keys as additive extension (ignore, don't fail); apply the staleness rules.
+**Consumer-side policy is out of contract.** A consumer may hold its own rule about which confidence it will act on unsupervised, and a high-consequence autonomous action is a reasonable place to hold one. That rule belongs to the consumer and its operator, and it is theirs to state and log. This pattern's job is to make the confidence legible and located, so a policy has something honest to act on; it is not to decide, on a product owner's behalf, what an agent may not read.
 
 ---
 
 ## 10. Schema Versioning and Evolution
 
-Every record carries `payload_schema_version`; the canonical version is **`2.0`**. **Wire schema `1.0`** is the registered legacy binding (the same status/count/score/JSON fields without the producer-identity, `source_format`, `payload_schema_version`, or `evidence_expires_dts` fields); consumers treat a 1.0 record as an implied single producer. Incompatible changes bump the major version; additive optional fields are compatible within a major version. Producer and consumer are held together by a **shared golden fixture**: both build gates fail on drift.
+Every record carries `payload_schema_version`; the canonical version is **`2.1`**. Incompatible changes bump the major version; additive optional fields are compatible within a major version.
+
+**Wire schema `2.1`** adds the area record, the `scope_kind` / `scope_id` keys on failed-check items, and the deprecation of `agent_use_allowed`. It is additive: a 2.0 reader parses a 2.1 run record unchanged.
+
+**Reading a 2.0 or 1.0 producer.** A producer that publishes no area records still has a readable map: consumers project its run record as one `PRODUCT`-scope entry, with `checks_expected` and `checks_ran` both taken from `total_checks` and the §4.3 rules applied to the run counts. A derived entry is **capped at `partial` confidence**, because a run-level pass says nothing about which areas it covered, and it is marked as derived rather than published so a consumer can tell the difference. The map then covers one area, the whole product, which is exactly as much as such a producer knows.
+
+**Wire schema `1.0`** remains the registered legacy binding (the same status/count/score/JSON fields without the producer-identity, `source_format`, `payload_schema_version`, or `evidence_expires_dts` fields); consumers treat a 1.0 record as an implied single producer. Producer and consumer are held together by a **shared golden fixture**: both build gates fail on drift.
 
 ---
 
 ## 11. Staleness and Incomplete Evidence
 
+Age and absence are **coverage facts**: they change what the map claims, not whether the product may be read.
+
 1. **Evidence window.** A producer may declare per-record expiry; a product may declare a maximum evidence age in orientation. Absent both, the default window is **7 days** from `completed_dts`.
-2. **Stale evidence** (past expiry / older than window): autonomous consumers treat the product as stop, whatever the recorded status; interactive consumers surface staleness prominently.
-3. **No evidence**: the product is *unvalidated* rather than trusted by default. Autonomous consumers must not proceed.
+2. **Stale evidence** (past expiry / older than window): every entry from that run reads at `confidence` = `unknown`, whatever it recorded, because a passed check proves the state of a product as it was. Consumers surface the staleness and its date, and `recommended_action` is to re-run the validator.
+3. **No evidence**: the area is *unvalidated* rather than sound. An area with no published entry reads as `no-evidence` / `unknown`, and a product with no published run has a map of one such entry.
 4. **Incomplete evidence** (`total_checks = 0` or unparseable): treat as no evidence.
 
-Staleness can only downgrade a decision, never upgrade one.
+Staleness can only downgrade confidence, never raise it. It does not block: an agent may answer from a stale product, and says that it did.
 
 ---
 
@@ -224,7 +310,8 @@ Staleness can only downgrade a decision, never upgrade one.
 
 - **`test_id` scheme:** `{PRODUCT-PREFIX}-{FAMILY}-{NNN}` (e.g. `CALLCENTRE-SEM-008`); parameterised checks may extend the suffix. Stable across runs. Ingested results map their native identity into this scheme deterministically.
 - **Categories** (drive score families): `STRUCTURAL`, `SEMANTIC`, `QUERY`, `CAPABILITY`, `PERFORMANCE`, `OPERATIONAL`, `DATA_QUALITY`, `FREE_TEXT`.
-- Validators prove the product's **self-describing metadata** (semantic catalogue, orientation manifest, relationships, cookbook) against what is physically deployed. The temporal pattern's `TLM-01..17` rules (blocking → CRITICAL/ERROR) and the Semantic module's primary-object validations lift directly into validator profiles: as do each module's own `INV-*` invariant checks.
+- **Scope** (drives the map): every check belongs to exactly one area. **By ownership, a check's scope is the module or pattern that owns it** — the checks shipped under a module's own directory are that module's area, and a pattern's conformance queries are that pattern's — so an existing check suite acquires its scope without being rewritten. A check that resolves a single entity or a single capability declares the narrower scope instead, and a check about the product as a whole declares `PRODUCT`. A category is what a check tests; a scope is what it tests *about*, and the two are independent: one `STRUCTURAL` check can belong to Domain and the next to Search.
+- Validators prove the product's **self-describing metadata** (semantic catalogue, orientation manifest, relationships, cookbook) against what is physically deployed. The temporal pattern's `TLM-01..17` rules (blocking → CRITICAL/ERROR) and the Semantic module's primary-object validations lift directly into validator profiles: as do each module's own `INV-*` invariant checks. Each lifts with the scope of the document that states it.
 
 ---
 
@@ -248,26 +335,32 @@ The result is mappable from/to established open formats; `source_format` records
 | Rule | Check |
 |------|-------|
 | VAL-01 | `trust_status` is exactly one of the three vocabulary values. |
-| VAL-02 | `agent_use_allowed` agrees with `trust_status` per the status vocabulary and decision semantics. |
-| VAL-03 | The default decision profile is never loosened. |
+| VAL-02 | `agent_use_allowed` is published as go on every 2.1 record, and no consumer branches on it at any version. |
+| VAL-03 | The default summary and confidence profiles are tightened toward caution or not at all, never loosened. |
 | VAL-04 | `total_checks = passed_count + failed_count + error_count`. |
-| VAL-05 | Gate counts are consistent with the severity model. |
+| VAL-05 | Severity counts are consistent with the severity model, on the run record and on every area entry. |
 | VAL-06 | Scores are 0-100 integers or null; null only when not assessed. |
 | VAL-07 | JSON blobs respect their caps; true totals live in `row_count` / `repair_candidate_count`. |
 | VAL-08 | Every `sample_rows` element carries `issue_code` and `repair_hint`; every issue code is catalogued. |
-| VAL-09 | Runs are appended; the latest-per-(product, producer) projection is deterministic (`completed_dts`, then `run_id`). |
-| VAL-10 | Consumers apply staleness outcomes; no silent override of a blocked gate. |
+| VAL-09 | Runs are appended; the latest-per-(product, producer) and latest-per-area projections are deterministic (`completed_dts`, then `run_id`). |
+| VAL-10 | Consumers apply staleness as a confidence downgrade, and disclose every area they used at `weak` or `unknown`. |
 | VAL-11 | Producer and consumer build gates verify the shared golden fixture at the declared schema version. |
 | VAL-12 | Every record carries non-null `producer_id` and `payload_schema_version`. |
-| VAL-13 | The gate is taken only from the designated producer; absent designation, the conservative composite applies. |
+| VAL-13 | The map is taken from the designated producer; absent designation, the most cautious entry per area applies and the consumer says so. |
+| VAL-14 | `scope_kind`, `area_status`, and `confidence` come from their vocabularies, and `scope_id` resolves to a real module, entity, pattern, capability, or the product. |
+| VAL-15 | Per area: `checks_ran = passed_count + failed_count + error_count`, and `checks_ran` never exceeds `checks_expected`. |
+| VAL-16 | `pass` and `strong` require checks that ran at full coverage; `no-evidence` and `not-validated` carry `confidence` = `unknown`. |
+| VAL-17 | Every entry below `strong` carries `open_gaps` and `recommended_action`. |
+| VAL-18 | Every area a run's profile covers has an entry, including uncovered ones; every failed check's scope resolves to an entry in the same run. |
 
 ---
 
 ## 15. Relationship to Other Standards
 
-- **[Observability module](../modules/observability.md)**: the module home for validation results, alongside its other run/event evidence.
-- **[Temporal & lifecycle metadata pattern](temporal-lifecycle-metadata.md)**: the results table declares profile `EVENT_APPEND_ONLY`; `TLM` blocking rules are canonical CRITICAL/ERROR checks.
-- **[Semantic module](../modules/semantic.md)**: its primary-object validations are canonical STRUCTURAL/SEMANTIC checks; product orientation declares the results location and the gate-authoritative producer, so trust evaluation precedes analytical resource use.
+- **[Observability module](../modules/observability.md)**: the module home for the run record and the trust map, alongside its other run/event evidence.
+- **[Temporal & lifecycle metadata pattern](temporal-lifecycle-metadata.md)**: both results relations declare profile `EVENT_APPEND_ONLY`; `TLM` blocking rules are canonical CRITICAL/ERROR checks, scoped to that pattern's area.
+- **[Semantic module](../modules/semantic.md)**: its primary-object validations are canonical STRUCTURAL/SEMANTIC checks; product orientation declares the results location and the trust-authoritative producer, so the map is read before analytical resource use. Its catalogue is also where an `ENTITY` scope resolves.
+- **`roles/review.md`**: a reviewer builds this same map by hand, in this vocabulary, before a validator exists to publish it. The two are the same artefact at different stages of a product's life.
 - **Implementation**: the Teradata binding (results table, DBC/data checks, wire-schema bindings) lives in [`implementation/teradata/patterns/validation/`](../../implementation/teradata/patterns/validation/).
 
 ---

--- a/design/patterns/validation.md
+++ b/design/patterns/validation.md
@@ -347,7 +347,7 @@ The result is mappable from/to established open formats; `source_format` records
 | VAL-11 | Producer and consumer build gates verify the shared golden fixture at the declared schema version. |
 | VAL-12 | Every record carries non-null `producer_id` and `payload_schema_version`. |
 | VAL-13 | The map is taken from the designated producer; absent designation, the most cautious entry per area applies and the consumer says so. |
-| VAL-14 | `scope_kind`, `area_status`, and `confidence` come from their vocabularies, and `scope_id` resolves to a real module, entity, pattern, capability, or the product. |
+| VAL-14 | `scope_kind`, `area_status`, and `confidence` come from their vocabularies, and `scope_id` resolves to a real module, entity, pattern, capability, or the product. Runtime-checkable for `PRODUCT`, `MODULE`, and `ENTITY` against deployed catalogue metadata; `PATTERN` and `CAPABILITY` have no deployed catalogue to resolve against, so the producer's build-time assertion against its own validator profile is the enforcement point. |
 | VAL-15 | Per area: `checks_ran = passed_count + failed_count + error_count`, and `checks_ran` never exceeds `checks_expected`. |
 | VAL-16 | `pass` and `strong` require checks that ran at full coverage; `no-evidence` and `not-validated` carry `confidence` = `unknown`. |
 | VAL-17 | Every entry below `strong` carries `open_gaps` and `recommended_action`. |

--- a/design/patterns/validation.md
+++ b/design/patterns/validation.md
@@ -273,7 +273,7 @@ Rules: the check-level identifier is **`test_id`** (`issue_code` exists only ins
 
 **The designation is made at design time.** Everything above is written from the consumer's side, and a consumer can only read a designation that already exists. VAL-13 is checked at runtime; the fact it checks has to be established while the product is being designed, because by deploy time the manifest is already written. So it is a designer's obligation, stated here rather than left to be inferred from the consumer rule:
 
-> Name the producer whose trust map is the product's authoritative one. Record it as a design decision, and carry it into the orientation manifest as `trust_authoritative_producer` (the [Semantic module](../modules/semantic.md) owns the field; `gate_authoritative_producer` is the legacy spelling and readers still honour it). Where the product has exactly one producer it is authoritative by definition, and must still be named: an implicit designation is not readable.
+> Name the producer whose trust map is the product's authoritative one. Record it as a design decision, and carry it into the orientation manifest as `trust_authoritative_producer` (the [Semantic module](../modules/semantic.md) owns the field). Where the product has exactly one producer it is authoritative by definition, and must still be named: an implicit designation is not readable.
 
 **Further consumer rules.** Never re-derive a status or a confidence, and never recount capped blobs: only a validator computes trust. Treat unknown JSON keys as additive extension (ignore, don't fail). Apply the staleness rules (§11).
 
@@ -288,6 +288,8 @@ Every record carries `payload_schema_version`; the canonical version is **`2.1`*
 **Wire schema `2.1`** adds the area record, the `scope_kind` / `scope_id` keys on failed-check items, and the deprecation of `agent_use_allowed`. It is additive: a 2.0 reader parses a 2.1 run record unchanged.
 
 **Reading a 2.0 or 1.0 producer.** A producer that publishes no area records still has a readable map: consumers project its run record as one `PRODUCT`-scope entry, with `checks_expected` and `checks_ran` both taken from `total_checks` and the §4.3 rules applied to the run counts. A derived entry is **capped at `partial` confidence**, because a run-level pass says nothing about which areas it covered, and it is marked as derived rather than published so a consumer can tell the difference. The map then covers one area, the whole product, which is exactly as much as such a producer knows.
+
+**Selecting records by version.** `payload_schema_version` is a version string, not an ordered number, so a reader must never select records by comparing it lexically. `'10.0'` sorts below `'2.1'`, so a reader written as "at least 2.1" silently stops covering the schema it was written for the moment a two-digit major version exists. **Registered legacy versions are enumerated explicitly**, and every other version is canonical-or-later by exclusion: a new major version is then covered by every check the day it appears, and registering a new legacy binding is a single edit per reader. This binds consumers and conformance checks alike.
 
 **Wire schema `1.0`** remains the registered legacy binding (the same status/count/score/JSON fields without the producer-identity, `source_format`, `payload_schema_version`, or `evidence_expires_dts` fields); consumers treat a 1.0 record as an implied single producer. Producer and consumer are held together by a **shared golden fixture**: both build gates fail on drift.
 

--- a/examples/it-service-desk-data-product/ITSD_Reference_Brief.md
+++ b/examples/it-service-desk-data-product/ITSD_Reference_Brief.md
@@ -507,10 +507,14 @@ Reviewer: [identity]
 Evidence sources: design brief, build SQL, live Teradata product (MCP)
 
 ### [Module Name]
-| Area | Coverage | Status | Confidence | Open Gaps |
-|---|---|---|---|---|
-| [invariant or rule id] | [checks that exist / ran] | pass/fail/not-yet-validated/no-evidence | strong/partial/weak/unknown | [prose] |
+| Area | Coverage | Status | Confidence | Open Gaps | Recommended Action |
+|---|---|---|---|---|---|
+| [scope, e.g. MODULE:domain or ENTITY:domain.Ticket] | [checks ran / checks expected] | pass/fail/partial/not-validated/no-evidence | strong/partial/weak/unknown | [prose] | [what would raise trust] |
 ```
+
+The vocabulary is the published one (`design/patterns/validation.md` §4), so the review's map is
+the same artefact a validator later publishes as `validation_area` rows. Cite the invariant or rule
+id behind each entry in the gaps column.
 
 **Severity:**
 

--- a/implementation/teradata/modules/observability/README.md
+++ b/implementation/teradata/modules/observability/README.md
@@ -22,14 +22,14 @@ Teradata binding of [`design/modules/observability.md`](../../../../design/modul
 | `03-lineage-views.sql.j2` | `lineage_graph` and `lineage_run_latest`: deployed into the Semantic container. |
 | `04-openlineage.md` | OpenLineage entity/column mapping and RunEvent construction. |
 
-**Validation results.** The `validation_run` table and its `validation_latest` gate view are defined by the [validation pattern implementation](../../patterns/validation/) and deployed into this module's `{{ product }}_Observability` container. This module does not redefine them.
+**Validation results.** The `validation_run` and `validation_area` tables and their `validation_latest` / `validation_trust_map` views are defined by the [validation pattern implementation](../../patterns/validation/) and deployed into this module's `{{ product }}_Observability` container. This module does not redefine them.
 
 ## Capability bindings
 
 | Capability (design) | Teradata binding |
 |---------------------|------------------|
 | Outcome & quality evidence | `agent_outcome`, `data_quality_metric`: read by Memory's closed-loop learning. |
-| Validation results home | Hosts the validation pattern's `validation_run`. |
+| Validation results home | Hosts the validation pattern's `validation_run` and `validation_area` (the trust map). |
 | Lineage | `data_lineage` + `lineage_run`, exposed via `lineage_graph` / `lineage_run_latest` in Semantic. |
 | `RichMetadata` | `COMMENT ON TABLE` / `COMMENT ON COLUMN`. |
 | `access-layer` write-back | `ROLE_AGENT` holds `INSERT` here (Phase 2.5). |
@@ -40,5 +40,5 @@ Teradata binding of [`design/modules/observability.md`](../../../../design/modul
 |-----------|--------------|
 | `INV-OBS-002` (table-level, aggregate) | Schema: `records_affected` count, `table_name` only: no instance-key columns. |
 | `INV-OBS-003` (lineage split) | Two tables: `data_lineage` (one row per flow) + `lineage_run` (one row per execution, FK to definition). |
-| `INV-OBS-005` (validation home) | `validation_run` deployed here (validation pattern), profile `EVENT_APPEND_ONLY`. |
+| `INV-OBS-005` (validation home) | `validation_run` and `validation_area` deployed here (validation pattern), profile `EVENT_APPEND_ONLY`. |
 | `INV-OBS-006` (stable graph) | `lineage_graph` reads `data_lineage WHERE is_active = 1` only. |

--- a/implementation/teradata/modules/semantic/03-registry.sql
+++ b/implementation/teradata/modules/semantic/03-registry.sql
@@ -23,6 +23,7 @@ CREATE MULTISET TABLE governance.data_product_registry
    ,query_cookbook_uri     VARCHAR(1000)
    ,approved_entrypoint    VARCHAR(1000)             -- approved first data-access surface
    ,approved_access_mode   VARCHAR(32)               -- VIEW, MCP_TOOL, SEMANTIC_QUERY
+   ,trust_authoritative_producer VARCHAR(64)         -- producer_id whose trust map is the product's authoritative one
    ,is_active              BYTEINT NOT NULL
    ,is_deleted             BYTEINT NOT NULL
    ,created_dts            TIMESTAMP(6) WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP(6)
@@ -51,6 +52,7 @@ COMMENT ON COLUMN governance.data_product_registry.glossary_uri IS 'URI for busi
 COMMENT ON COLUMN governance.data_product_registry.query_cookbook_uri IS 'URI for validated query recipes (Memory).';
 COMMENT ON COLUMN governance.data_product_registry.approved_entrypoint IS 'Approved first data-access surface (access view, semantic view, MCP tool).';
 COMMENT ON COLUMN governance.data_product_registry.approved_access_mode IS 'VIEW, MCP_TOOL, SEMANTIC_QUERY, or site-defined.';
+COMMENT ON COLUMN governance.data_product_registry.trust_authoritative_producer IS 'producer_id whose validation trust map is this product''s authoritative one; other producers publish evidence. Named at design time - an implicit designation is not readable (validation pattern, VAL-13).';
 COMMENT ON COLUMN governance.data_product_registry.is_active IS '1 = current and discoverable, 0 = inactive.';
 COMMENT ON COLUMN governance.data_product_registry.is_deleted IS '1 = logically deleted and hidden, 0 = discoverable when active.';
 COMMENT ON COLUMN governance.data_product_registry.created_dts IS 'When this row was created.';

--- a/implementation/teradata/modules/semantic/06-orientation.md
+++ b/implementation/teradata/modules/semantic/06-orientation.md
@@ -58,7 +58,7 @@ recommended_navigation:
  - data_access
 ```
 
-The manifest tells the agent what the product is, what it means, what it trusts, what it may access, and how to proceed. The registry also names the **gate-authoritative producer** the [validation pattern](../../patterns/validation/) reads, so trust evaluation precedes analytical use.
+The manifest tells the agent what the product is, what it means, what it trusts, what it may access, and how to proceed. The registry also names the **trust-authoritative producer** (`trust_authoritative_producer`) whose per-area trust map the [validation pattern](../../patterns/validation/) reads, and the `TRUST_MAP` orientation role is ordered before every analytical resource, so an agent knows how far to trust an area before it queries it. `TRUST_GATE` is the legacy spelling of that role and readers honour both.
 
 ## Required documentation record
 

--- a/implementation/teradata/modules/semantic/09-orientation-manifest.sql.j2
+++ b/implementation/teradata/modules/semantic/09-orientation-manifest.sql.j2
@@ -55,9 +55,14 @@ SELECT
       r.product_id, r.product_name, r.product_version, r.product_status, r.owner_team
     , r.approved_access_mode, r.approved_entrypoint
     , MAX(CASE WHEN o.resource_role = 'MANIFEST'               THEN o.fully_qualified_object_name END)
-      -- TRUST_GATE is the legacy spelling of TRUST_MAP; readers honour both.
-    , MAX(CASE WHEN o.resource_role IN ('TRUST_MAP', 'TRUST_GATE')
-                                                               THEN o.fully_qualified_object_name END)
+      -- TRUST_GATE is the legacy spelling of TRUST_MAP; readers honour both. A product publishing
+      -- both fails the singular-role conformance check (validation.sql.j2, INV-SEMANTIC-011), but
+      -- while it exists this deterministically prefers the canonical spelling over MAX(...) string
+      -- ordering, so an already-corrected product still reads its legacy-only predecessor.
+    , COALESCE(
+          MAX(CASE WHEN o.resource_role = 'TRUST_MAP' THEN o.fully_qualified_object_name END)
+        , MAX(CASE WHEN o.resource_role = 'TRUST_GATE' THEN o.fully_qualified_object_name END)
+      )
     , MAX(CASE WHEN o.resource_role = 'MODULE_MAP'             THEN o.fully_qualified_object_name END)
     , MAX(CASE WHEN o.resource_role = 'OBJECT_CATALOGUE'       THEN o.fully_qualified_object_name END)
     , MAX(CASE WHEN o.resource_role = 'ENTITY_CATALOGUE'       THEN o.fully_qualified_object_name END)

--- a/implementation/teradata/modules/semantic/09-orientation-manifest.sql.j2
+++ b/implementation/teradata/modules/semantic/09-orientation-manifest.sql.j2
@@ -17,7 +17,7 @@ CREATE TABLE {{ product }}_Semantic.data_product_orientation (
     resource_uri VARCHAR(1000),                 -- URI for an MCP or external resource
     usage_guidance VARCHAR(500),
     is_required BYTEINT NOT NULL DEFAULT 0,      -- 1 = a missing resource is a conformance failure
-    discovery_order SMALLINT NOT NULL,           -- ascending processing order; trust gate precedes analytics
+    discovery_order SMALLINT NOT NULL,           -- ascending processing order; trust map precedes analytics
     is_active BYTEINT NOT NULL DEFAULT 1,
 {{ tlm.columns('CURRENT_STATE', pad=8) }}
 )
@@ -33,7 +33,7 @@ COMMENT ON COLUMN {{ product }}_Semantic.data_product_orientation.fully_qualifie
 COMMENT ON COLUMN {{ product }}_Semantic.data_product_orientation.resource_uri IS 'URI for a resource exposed as MCP or external documentation rather than a database object.';
 COMMENT ON COLUMN {{ product }}_Semantic.data_product_orientation.usage_guidance IS 'How a consumer should use this resource.';
 COMMENT ON COLUMN {{ product }}_Semantic.data_product_orientation.is_required IS '1 = a consumer must resolve this resource; its absence is a conformance failure.';
-COMMENT ON COLUMN {{ product }}_Semantic.data_product_orientation.discovery_order IS 'Ascending processing order; the trust gate role precedes every analytical resource.';
+COMMENT ON COLUMN {{ product }}_Semantic.data_product_orientation.discovery_order IS 'Ascending processing order; the TRUST_MAP role precedes every analytical resource.';
 COMMENT ON COLUMN {{ product }}_Semantic.data_product_orientation.is_active IS '1 = live orientation row, 0 = retired.';
 {{ tlm.comments(product ~ '_Semantic.data_product_orientation', 'CURRENT_STATE') }}
 
@@ -44,10 +44,10 @@ REPLACE VIEW {{ product }}_Semantic.data_product_manifest
 (
       product_id, product_name, product_version, product_status, owner_team
     , approved_access_mode, approved_entrypoint
-    , manifest_entrypoint, trust_entrypoint, module_map_entrypoint
+    , manifest_entrypoint, trust_map_entrypoint, module_map_entrypoint
     , object_catalogue_entrypoint, entity_catalogue_entrypoint
     , column_catalogue_entrypoint, relationship_catalogue_entrypoint
-    , manifest_json
+    , trust_authoritative_producer, manifest_json
 )
 AS
 LOCKING ROW FOR ACCESS
@@ -55,12 +55,15 @@ SELECT
       r.product_id, r.product_name, r.product_version, r.product_status, r.owner_team
     , r.approved_access_mode, r.approved_entrypoint
     , MAX(CASE WHEN o.resource_role = 'MANIFEST'               THEN o.fully_qualified_object_name END)
-    , MAX(CASE WHEN o.resource_role = 'TRUST_GATE'             THEN o.fully_qualified_object_name END)
+      -- TRUST_GATE is the legacy spelling of TRUST_MAP; readers honour both.
+    , MAX(CASE WHEN o.resource_role IN ('TRUST_MAP', 'TRUST_GATE')
+                                                               THEN o.fully_qualified_object_name END)
     , MAX(CASE WHEN o.resource_role = 'MODULE_MAP'             THEN o.fully_qualified_object_name END)
     , MAX(CASE WHEN o.resource_role = 'OBJECT_CATALOGUE'       THEN o.fully_qualified_object_name END)
     , MAX(CASE WHEN o.resource_role = 'ENTITY_CATALOGUE'       THEN o.fully_qualified_object_name END)
     , MAX(CASE WHEN o.resource_role = 'COLUMN_CATALOGUE'       THEN o.fully_qualified_object_name END)
     , MAX(CASE WHEN o.resource_role = 'RELATIONSHIP_CATALOGUE' THEN o.fully_qualified_object_name END)
+    , r.trust_authoritative_producer
     , r.manifest_json
 FROM governance.data_product_registry AS r
 LEFT JOIN {{ product }}_Semantic.data_product_orientation AS o
@@ -69,7 +72,8 @@ LEFT JOIN {{ product }}_Semantic.data_product_orientation AS o
 WHERE r.is_active = 1 AND r.is_deleted = 0
 GROUP BY
       r.product_id, r.product_name, r.product_version, r.product_status, r.owner_team
-    , r.approved_access_mode, r.approved_entrypoint, r.manifest_json;
+    , r.approved_access_mode, r.approved_entrypoint
+    , r.trust_authoritative_producer, r.manifest_json;
 
 COMMENT ON VIEW {{ product }}_Semantic.data_product_manifest IS
 'Machine-readable product manifest - generated from data_product_registry and data_product_orientation, so it cannot drift. Read first, then follow orientation in discovery_order.';

--- a/implementation/teradata/modules/semantic/README.md
+++ b/implementation/teradata/modules/semantic/README.md
@@ -61,5 +61,5 @@ New catalogue tables use the canonical `created_dts`/`updated_dts` audit columns
 | `INV-SEMANTIC-008` (resolve through the registry) | `validation.sql.j2`: registered access object not deployed. |
 | `INV-SEMANTIC-009` (consumable objects resolve to a catalogued entity) | `validation.sql.j2`: non-composite with no entity; `represents_entity` / `member_entity` not catalogued. |
 | `INV-SEMANTIC-010` (composite structure recorded, one anchor) | `validation.sql.j2`: COMPOSITE without a composition; composition without exactly one `ANCHOR`. |
-| `INV-SEMANTIC-011` (ordered orientation, trust gate first) | `validation.sql.j2`: missing required role, duplicate role, duplicate order, undeployed object, unordered trust gate. |
+| `INV-SEMANTIC-011` (ordered orientation, trust map first) | `validation.sql.j2`: missing required role, duplicate role, duplicate order, undeployed object, unordered trust map. Also `VAL-13`: the registry names the trust-authoritative producer. |
 | `INV-SEMANTIC-012` (manifest generated, cannot drift) | `validation.sql.j2`: a manifest entrypoint with no backing active orientation row. |

--- a/implementation/teradata/modules/semantic/validation.sql.j2
+++ b/implementation/teradata/modules/semantic/validation.sql.j2
@@ -110,14 +110,16 @@ HAVING SUM(CASE WHEN c.member_role = 'ANCHOR' THEN 1 ELSE 0 END) <> 1;
 SELECT r.product_id, req.resource_role
 FROM {{ product }}_Semantic.data_product_orientation AS r
 CROSS JOIN (SELECT 'MANIFEST' AS resource_role
-      UNION SELECT 'TRUST_GATE' UNION SELECT 'MODULE_MAP'
+      UNION SELECT 'TRUST_MAP' UNION SELECT 'MODULE_MAP'
       UNION SELECT 'OBJECT_CATALOGUE' UNION SELECT 'ENTITY_CATALOGUE'
       UNION SELECT 'COLUMN_CATALOGUE' UNION SELECT 'RELATIONSHIP_CATALOGUE') AS req
 WHERE r.is_active = 1
   AND NOT EXISTS (
       SELECT 1 FROM {{ product }}_Semantic.data_product_orientation AS o
       WHERE o.product_id = r.product_id AND o.is_active = 1
-        AND o.resource_role = req.resource_role)
+        AND (o.resource_role = req.resource_role
+             -- TRUST_GATE is the legacy spelling of TRUST_MAP; either satisfies the role.
+             OR (req.resource_role = 'TRUST_MAP' AND o.resource_role = 'TRUST_GATE')))
 GROUP BY r.product_id, req.resource_role;
 
 -- INV-SEMANTIC-011: duplicate active role for one product (each role is singular)
@@ -141,7 +143,7 @@ LEFT JOIN DBC.TablesV AS t
     ON t.DatabaseName = o.database_name AND t.TableName = o.object_name
 WHERE o.is_active = 1 AND o.object_name IS NOT NULL AND t.TableName IS NULL;
 
--- INV-SEMANTIC-011: trust gate not ordered before every analytical resource
+-- INV-SEMANTIC-011: trust map not ordered before every analytical resource
 SELECT o.product_id
 FROM {{ product }}_Semantic.data_product_orientation AS o
 WHERE o.is_active = 1
@@ -151,11 +153,19 @@ WHERE o.is_active = 1
       SELECT MIN(g.discovery_order)
       FROM {{ product }}_Semantic.data_product_orientation AS g
       WHERE g.product_id = o.product_id AND g.is_active = 1
-        AND g.resource_role = 'TRUST_GATE');
+        AND g.resource_role IN ('TRUST_MAP', 'TRUST_GATE'));
 
 -- INV-SEMANTIC-012: a manifest entrypoint with no backing active orientation row
 SELECT m.product_id
 FROM {{ product }}_Semantic.data_product_manifest AS m
 WHERE m.manifest_entrypoint IS NULL
-   OR m.trust_entrypoint IS NULL
+   OR m.trust_map_entrypoint IS NULL
    OR m.entity_catalogue_entrypoint IS NULL;
+
+-- VAL-13: the product designates the producer whose trust map is authoritative. An implicit
+-- designation is not readable, so a product with a validator and no designation has two maps
+-- and no statement of which one it means.
+SELECT m.product_id
+FROM {{ product }}_Semantic.data_product_manifest AS m
+WHERE m.trust_authoritative_producer IS NULL
+   OR TRIM(m.trust_authoritative_producer) = '';

--- a/implementation/teradata/modules/semantic/validation.sql.j2
+++ b/implementation/teradata/modules/semantic/validation.sql.j2
@@ -122,11 +122,19 @@ WHERE r.is_active = 1
              OR (req.resource_role = 'TRUST_MAP' AND o.resource_role = 'TRUST_GATE')))
 GROUP BY r.product_id, req.resource_role;
 
--- INV-SEMANTIC-011: duplicate active role for one product (each role is singular)
-SELECT product_id, resource_role, COUNT(*) AS n
-FROM {{ product }}_Semantic.data_product_orientation
-WHERE is_active = 1
-GROUP BY product_id, resource_role
+-- INV-SEMANTIC-011: duplicate active role for one product (each role is singular). TRUST_GATE and
+-- TRUST_MAP are the same role under two spellings (see the manifest's alias projection below), so
+-- they are canonicalised before grouping - otherwise a product publishing both passes this check.
+SELECT product_id, canonical_resource_role, COUNT(*) AS n
+FROM (
+    SELECT product_id
+         , CASE WHEN resource_role IN ('TRUST_MAP', 'TRUST_GATE') THEN 'TRUST_MAP'
+                ELSE resource_role
+           END AS canonical_resource_role
+    FROM {{ product }}_Semantic.data_product_orientation
+    WHERE is_active = 1
+) AS c
+GROUP BY product_id, canonical_resource_role
 HAVING COUNT(*) > 1;
 
 -- INV-SEMANTIC-011: duplicate discovery_order for one product

--- a/implementation/teradata/patterns/validation/01-validation-run.sql
+++ b/implementation/teradata/patterns/validation/01-validation-run.sql
@@ -1,4 +1,5 @@
--- Validation: results table (Teradata). Binding of the validation result contract in design/patterns/validation.md.
+-- Validation: run record (Teradata). Binding of the validation result contract in design/patterns/validation.md.
+-- The run-level summary; the per-area trust map is 03-validation-area.sql.
 -- Operational evidence in the Observability module; append-only (EVENT_APPEND_ONLY).
 -- {db} is a generic tag bound by object-placement, e.g. {Product}_Observability.
 
@@ -12,18 +13,20 @@ CREATE MULTISET TABLE {db}.validation_run
     profile_id VARCHAR(64) CHARACTER SET LATIN,
     profile_version VARCHAR(32) CHARACTER SET LATIN,
     source_format VARCHAR(20) CHARACTER SET LATIN NOT NULL DEFAULT 'NATIVE',
-    payload_schema_version VARCHAR(8) CHARACTER SET LATIN NOT NULL DEFAULT '2.0',
+    payload_schema_version VARCHAR(8) CHARACTER SET LATIN NOT NULL DEFAULT '2.1',
 
     -- Run identity
     run_id VARCHAR(64) CHARACTER SET LATIN NOT NULL,
     started_dts TIMESTAMP(6) WITH TIME ZONE NOT NULL,
     completed_dts TIMESTAMP(6) WITH TIME ZONE NOT NULL,
 
-    -- Gate result
+    -- Advisory product-level summary of the map (§4.4). Not permission, not a decision.
     trust_status VARCHAR(16) CHARACTER SET LATIN NOT NULL,
+    -- Deprecated at schema 2.1: kept so a 2.0 reader still parses the record. A 2.1 producer
+    -- publishes 1 and no consumer branches on it; the trust map carries what mattered here.
     agent_use_allowed BYTEINT NOT NULL CHECK (agent_use_allowed IN (0, 1)),
 
-    -- Check totals (status axis) and gate counts (severity axis)
+    -- Check totals (status axis) and counts by severity
     total_checks INTEGER NOT NULL,
     passed_count INTEGER NOT NULL,
     failed_count INTEGER NOT NULL,

--- a/implementation/teradata/patterns/validation/02-views.sql
+++ b/implementation/teradata/patterns/validation/02-views.sql
@@ -1,6 +1,7 @@
--- Validation: latest-run / gate view (Teradata). Binding of the consumption contract and gate authority in design/patterns/validation.md.
+-- Validation: latest-run view (Teradata). Binding of the run record in design/patterns/validation.md §3.1.
 -- Latest-per-(product, producer) projection. The deterministic tie-break
 -- (completed_dts DESC, run_id DESC) is part of the contract (VAL-09).
+-- This is the run-level summary; the per-area trust map a consumer reads is 04-trust-map-views.sql.
 -- {db} is a generic tag, e.g. {Product}_Observability.
 
 REPLACE VIEW {db}.validation_latest
@@ -38,5 +39,7 @@ QUALIFY ROW_NUMBER() OVER (
     ORDER BY completed_dts DESC, run_id DESC
 ) = 1;
 
--- The product-level gate is the row whose producer_id matches the gate-authoritative
+-- The authoritative summary is the row whose producer_id matches the trust-authoritative
 -- producer designated in the product's orientation metadata; other rows are evidence.
+-- trust_status here is advisory: a consumer deciding how far to rely on something reads
+-- validation_trust_map for the areas it is about to query.

--- a/implementation/teradata/patterns/validation/03-validation-area.sql
+++ b/implementation/teradata/patterns/validation/03-validation-area.sql
@@ -1,0 +1,80 @@
+-- Validation: trust-map area table (Teradata). Binding of the area record in design/patterns/validation.md §3.2.
+-- One row per run per area: the per-area picture a consumer reads before using that area.
+-- Operational evidence in the Observability module; append-only (EVENT_APPEND_ONLY).
+-- {db} is a generic tag bound by object-placement, e.g. {Product}_Observability.
+
+CREATE MULTISET TABLE {db}.validation_area
+(
+    -- Parentage: the run this entry belongs to ({db}.validation_run)
+    product_prefix VARCHAR(128) CHARACTER SET LATIN NOT NULL,
+    producer_id VARCHAR(64) CHARACTER SET LATIN NOT NULL,
+    run_id VARCHAR(64) CHARACTER SET LATIN NOT NULL,
+
+    -- The area (§4.1)
+    scope_kind VARCHAR(16) CHARACTER SET LATIN NOT NULL
+        CHECK (scope_kind IN ('MODULE', 'ENTITY', 'PATTERN', 'CAPABILITY', 'PRODUCT')),
+    scope_id VARCHAR(128) CHARACTER SET LATIN NOT NULL,
+
+    -- Coverage: what the profile defines here, and what actually ran (§4.2)
+    checks_expected INTEGER NOT NULL,
+    checks_ran INTEGER NOT NULL,
+
+    -- Outcomes within the area (status axis) and severity counts
+    passed_count INTEGER NOT NULL,
+    failed_count INTEGER NOT NULL,
+    error_count INTEGER NOT NULL,
+    critical_failure_count INTEGER NOT NULL,
+    error_failure_count INTEGER NOT NULL,
+
+    -- Verdict for the area (§4.3): informs use, never withholds it
+    area_status VARCHAR(16) CHARACTER SET LATIN NOT NULL
+        CHECK (area_status IN ('pass', 'fail', 'partial', 'not-validated', 'no-evidence')),
+    confidence VARCHAR(8) CHARACTER SET LATIN NOT NULL
+        CHECK (confidence IN ('strong', 'partial', 'weak', 'unknown')),
+
+    -- Guidance: required unless confidence is 'strong' (VAL-17)
+    open_gaps VARCHAR(1000) CHARACTER SET UNICODE,
+    recommended_action VARCHAR(1000) CHARACTER SET UNICODE,
+
+    -- Inherited from the run, so the latest-per-area projection is deterministic
+    completed_dts TIMESTAMP(6) WITH TIME ZONE NOT NULL,
+
+    -- Row audit (temporal-lifecycle pattern, EVENT_APPEND_ONLY)
+    created_dts TIMESTAMP(6) WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_dts TIMESTAMP(6) WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP(6)
+)
+PRIMARY INDEX (product_prefix, scope_kind, scope_id);
+
+COMMENT ON TABLE {db}.validation_area IS
+'Trust map - one append-only row per validation run per area (module, entity, pattern, capability, product): coverage, outcome, confidence, and what would raise it. Read the areas a query touches; nothing here blocks use.';
+COMMENT ON COLUMN {db}.validation_area.product_prefix IS 'Product identity the run evaluated; joins to validation_run.';
+COMMENT ON COLUMN {db}.validation_area.producer_id IS 'Producing validator; the trust-authoritative producer named in orientation owns the map.';
+COMMENT ON COLUMN {db}.validation_area.run_id IS 'Run this entry belongs to; joins to validation_run.run_id.';
+COMMENT ON COLUMN {db}.validation_area.scope_kind IS 'What kind of area this entry describes: MODULE, ENTITY, PATTERN, CAPABILITY or PRODUCT.';
+COMMENT ON COLUMN {db}.validation_area.scope_id IS 'Identity of the area - module or pattern anchor, qualified entity, capability name, or the product prefix. Taken from the corpus and the Semantic catalogue, never derived from an object name.';
+COMMENT ON COLUMN {db}.validation_area.checks_expected IS 'Checks the profile defines for this area; 0 means none is defined, which reads as no-evidence rather than as nothing wrong.';
+COMMENT ON COLUMN {db}.validation_area.checks_ran IS 'How many of the expected checks executed in this run; coverage is checks_ran / checks_expected, derived on read.';
+COMMENT ON COLUMN {db}.validation_area.passed_count IS 'Checks in this area with status PASSED.';
+COMMENT ON COLUMN {db}.validation_area.failed_count IS 'Checks in this area with status FAILED, any severity.';
+COMMENT ON COLUMN {db}.validation_area.error_count IS 'Checks in this area that could not execute (status ERROR).';
+COMMENT ON COLUMN {db}.validation_area.critical_failure_count IS 'Failed or errored checks in this area at CRITICAL severity.';
+COMMENT ON COLUMN {db}.validation_area.error_failure_count IS 'Failed or errored checks in this area at ERROR severity.';
+COMMENT ON COLUMN {db}.validation_area.area_status IS 'What happened here: pass, fail, partial (clean but incomplete cover), not-validated (checks defined, none ran), no-evidence (no check defined).';
+COMMENT ON COLUMN {db}.validation_area.confidence IS 'How far this entry supports use of the area: strong, partial, weak, unknown. Severity-weighted and coverage-aware; advisory to the consumer, never permission.';
+COMMENT ON COLUMN {db}.validation_area.open_gaps IS 'What is uncovered or unproven in this area. Required unless confidence is strong.';
+COMMENT ON COLUMN {db}.validation_area.recommended_action IS 'What would raise confidence here - a check to write, a re-run, a metadata backfill, a design decision to settle. Required unless confidence is strong.';
+COMMENT ON COLUMN {db}.validation_area.completed_dts IS 'Completion instant inherited from the run, so latest-per-area ordering matches latest-per-run.';
+COMMENT ON COLUMN {db}.validation_area.created_dts IS 'When this row was appended.';
+COMMENT ON COLUMN {db}.validation_area.updated_dts IS 'When this row was last touched; append-only evidence, so equal to created_dts.';
+
+-- Declares temporal_pattern = EVENT_APPEND_ONLY in the Semantic entity metadata.
+-- Apply the comments above as their own step, then collect statistics:
+COLLECT STATISTICS
+      COLUMN (product_prefix)
+    , COLUMN (producer_id)
+    , COLUMN (run_id)
+    , COLUMN (product_prefix, producer_id)
+    , COLUMN (scope_kind, scope_id)
+    , COLUMN (product_prefix, scope_kind, scope_id)
+    , COLUMN (product_prefix, completed_dts)
+ON {db}.validation_area;

--- a/implementation/teradata/patterns/validation/04-trust-map-views.sql
+++ b/implementation/teradata/patterns/validation/04-trust-map-views.sql
@@ -1,0 +1,98 @@
+-- Validation: trust-map view (Teradata). Binding of the trust map and its consumption contract
+-- in design/patterns/validation.md §4, §9, §10.
+-- Latest-per-(product, producer, area) projection, with coverage derived on read. The deterministic
+-- tie-break (completed_dts DESC, run_id DESC) is part of the contract (VAL-09).
+-- A producer publishing no area rows is at wire schema 2.0; its run record projects a single
+-- PRODUCT-scope entry here, capped at 'partial' confidence, so the map has one shape everywhere.
+-- {db} is a generic tag, e.g. {Product}_Observability.
+
+REPLACE VIEW {db}.validation_trust_map
+AS
+LOCKING ROW FOR ACCESS
+SELECT
+      a.product_prefix
+    , a.producer_id
+    , a.run_id
+    , a.scope_kind
+    , a.scope_id
+    , a.checks_expected
+    , a.checks_ran
+    , CASE WHEN a.checks_expected > 0
+           THEN CAST(a.checks_ran AS DECIMAL(9, 4)) / a.checks_expected
+      END AS coverage_ratio
+    , a.passed_count
+    , a.failed_count
+    , a.error_count
+    , a.critical_failure_count
+    , a.error_failure_count
+    , a.area_status
+    , a.confidence
+    , a.open_gaps
+    , a.recommended_action
+    , a.completed_dts
+    , 'PUBLISHED' AS map_source
+-- The latest run per area is resolved in a derived table: QUALIFY is scoped to its own query
+-- block, and nesting it keeps the projection unambiguous across the UNION below.
+FROM (
+    SELECT
+          product_prefix, producer_id, run_id
+        , scope_kind, scope_id
+        , checks_expected, checks_ran
+        , passed_count, failed_count, error_count
+        , critical_failure_count, error_failure_count
+        , area_status, confidence
+        , open_gaps, recommended_action
+        , completed_dts
+    FROM {db}.validation_area
+    QUALIFY ROW_NUMBER() OVER (
+        PARTITION BY product_prefix, producer_id, scope_kind, scope_id
+        ORDER BY completed_dts DESC, run_id DESC
+    ) = 1
+) AS a
+
+UNION ALL
+
+-- Wire schema 2.0 / 1.0 fallback: derive one PRODUCT entry from the run counts (§10).
+SELECT
+      v.product_prefix
+    , v.producer_id
+    , v.run_id
+    , 'PRODUCT' AS scope_kind
+    , v.product_prefix AS scope_id
+    , v.total_checks AS checks_expected
+    , v.total_checks AS checks_ran
+    , CASE WHEN v.total_checks > 0 THEN CAST(1 AS DECIMAL(9, 4)) END AS coverage_ratio
+    , v.passed_count
+    , v.failed_count
+    , v.error_count
+    , v.critical_failure_count
+    , v.error_failure_count
+    , CASE WHEN v.total_checks = 0                              THEN 'no-evidence'
+           WHEN v.failed_count + v.error_count > 0              THEN 'fail'
+           ELSE 'pass'
+      END AS area_status
+      -- Capped at 'partial': a run-level pass says nothing about which areas it covered.
+    , CASE WHEN v.total_checks = 0                              THEN 'unknown'
+           WHEN v.critical_failure_count + v.error_failure_count > 0
+             OR v.error_count > 0                               THEN 'weak'
+           ELSE 'partial'
+      END AS confidence
+    , 'Producer publishes no per-area map (wire schema 2.0), so trust is stated for the whole product only and cannot be resolved to the area a query touches.' AS open_gaps
+    , 'Upgrade the validator to publish validation_area entries at wire schema 2.1.' AS recommended_action
+    , v.completed_dts
+    , 'DERIVED' AS map_source
+FROM {db}.validation_latest AS v
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM {db}.validation_area AS a
+    WHERE a.product_prefix = v.product_prefix
+      AND a.producer_id    = v.producer_id
+);
+
+COMMENT ON VIEW {db}.validation_trust_map IS
+'Trust map - latest entry per product, producer and area, with coverage derived on read. Read the areas a query touches, proceed, and disclose their confidence and gaps. Nothing here withholds use of the product.';
+
+-- The authoritative map is the set of rows whose producer_id matches the trust-authoritative
+-- producer designated in the product's orientation metadata; other producers' rows are evidence.
+-- Absent a designation, take the most cautious entry per area across producers and say so
+-- (see consumer-queries.sql).

--- a/implementation/teradata/patterns/validation/04-trust-map-views.sql
+++ b/implementation/teradata/patterns/validation/04-trust-map-views.sql
@@ -1,9 +1,12 @@
 -- Validation: trust-map view (Teradata). Binding of the trust map and its consumption contract
--- in design/patterns/validation.md §4, §9, §10.
+-- in design/patterns/validation.md §4, §9, §10, §11.
 -- Latest-per-(product, producer, area) projection, with coverage derived on read. The deterministic
 -- tie-break (completed_dts DESC, run_id DESC) is part of the contract (VAL-09).
 -- A producer publishing no area rows is at wire schema 2.0; its run record projects a single
 -- PRODUCT-scope entry here, capped at 'partial' confidence, so the map has one shape everywhere.
+-- Staleness (§11) is evaluated per area against the run that actually produced it, not against
+-- the producer's latest run: two areas in this map can come from different runs, so evaluating
+-- staleness against "the latest run" would grade older evidence by a newer run's clock.
 -- {db} is a generic tag, e.g. {Product}_Observability.
 
 REPLACE VIEW {db}.validation_trust_map
@@ -26,33 +29,51 @@ SELECT
     , a.critical_failure_count
     , a.error_failure_count
     , a.area_status
-    , a.confidence
+    -- Stale evidence reads at 'unknown' whatever it recorded (§11); the run's own declared
+    -- expiry wins, else the default 7-day window from the completion this area belongs to.
+    , CASE WHEN a.evidence_is_stale = 1 THEN 'unknown' ELSE a.confidence END AS confidence
+    , a.confidence AS recorded_confidence
+    , a.evidence_is_stale
     , a.open_gaps
-    , a.recommended_action
+    , CASE WHEN a.evidence_is_stale = 1
+           THEN 'Evidence has expired; re-run the validator for this area.'
+           ELSE a.recommended_action
+      END AS recommended_action
+    , a.recommended_action AS recorded_recommended_action
     , a.completed_dts
     , 'PUBLISHED' AS map_source
 -- The latest run per area is resolved in a derived table: QUALIFY is scoped to its own query
--- block, and nesting it keeps the projection unambiguous across the UNION below.
+-- block, and nesting it keeps the projection unambiguous across the UNION below. Joined to its
+-- own parent run (not the producer's latest run) so staleness reflects the evidence's own age.
 FROM (
     SELECT
-          product_prefix, producer_id, run_id
-        , scope_kind, scope_id
-        , checks_expected, checks_ran
-        , passed_count, failed_count, error_count
-        , critical_failure_count, error_failure_count
-        , area_status, confidence
-        , open_gaps, recommended_action
-        , completed_dts
-    FROM {db}.validation_area
+          la.product_prefix, la.producer_id, la.run_id
+        , la.scope_kind, la.scope_id
+        , la.checks_expected, la.checks_ran
+        , la.passed_count, la.failed_count, la.error_count
+        , la.critical_failure_count, la.error_failure_count
+        , la.area_status, la.confidence
+        , la.open_gaps, la.recommended_action
+        , la.completed_dts
+        , CASE WHEN COALESCE(r.evidence_expires_dts, la.completed_dts + INTERVAL '7' DAY)
+                    < CURRENT_TIMESTAMP(6)
+               THEN 1 ELSE 0
+          END AS evidence_is_stale
+    FROM {db}.validation_area AS la
+    INNER JOIN {db}.validation_run AS r
+            ON  r.product_prefix = la.product_prefix
+            AND r.producer_id    = la.producer_id
+            AND r.run_id         = la.run_id
     QUALIFY ROW_NUMBER() OVER (
-        PARTITION BY product_prefix, producer_id, scope_kind, scope_id
-        ORDER BY completed_dts DESC, run_id DESC
+        PARTITION BY la.product_prefix, la.producer_id, la.scope_kind, la.scope_id
+        ORDER BY la.completed_dts DESC, la.run_id DESC
     ) = 1
 ) AS a
 
 UNION ALL
 
--- Wire schema 2.0 / 1.0 fallback: derive one PRODUCT entry from the run counts (§10).
+-- Wire schema 2.0 / 1.0 fallback: derive one PRODUCT entry from the run counts (§10), staleness
+-- evaluated against this same run since there is only one row to derive it from.
 SELECT
       v.product_prefix
     , v.producer_id
@@ -72,25 +93,47 @@ SELECT
            ELSE 'pass'
       END AS area_status
       -- Capped at 'partial': a run-level pass says nothing about which areas it covered.
+    , CASE WHEN COALESCE(v.evidence_expires_dts, v.completed_dts + INTERVAL '7' DAY)
+                < CURRENT_TIMESTAMP(6)                           THEN 'unknown'
+           WHEN v.total_checks = 0                               THEN 'unknown'
+           WHEN v.critical_failure_count + v.error_failure_count > 0
+             OR v.error_count > 0                                THEN 'weak'
+           ELSE 'partial'
+      END AS confidence
     , CASE WHEN v.total_checks = 0                              THEN 'unknown'
            WHEN v.critical_failure_count + v.error_failure_count > 0
              OR v.error_count > 0                               THEN 'weak'
            ELSE 'partial'
-      END AS confidence
+      END AS recorded_confidence
+    , CASE WHEN COALESCE(v.evidence_expires_dts, v.completed_dts + INTERVAL '7' DAY)
+                < CURRENT_TIMESTAMP(6) THEN 1 ELSE 0
+      END AS evidence_is_stale
     , 'Producer publishes no per-area map (wire schema 2.0), so trust is stated for the whole product only and cannot be resolved to the area a query touches.' AS open_gaps
-    , 'Upgrade the validator to publish validation_area entries at wire schema 2.1.' AS recommended_action
+    , CASE WHEN COALESCE(v.evidence_expires_dts, v.completed_dts + INTERVAL '7' DAY)
+                < CURRENT_TIMESTAMP(6)
+           THEN 'Evidence has expired; re-run the validator for this product.'
+           ELSE 'Upgrade the validator to publish validation_area entries at wire schema 2.1.'
+      END AS recommended_action
+    , 'Upgrade the validator to publish validation_area entries at wire schema 2.1.' AS recorded_recommended_action
     , v.completed_dts
     , 'DERIVED' AS map_source
 FROM {db}.validation_latest AS v
-WHERE NOT EXISTS (
+-- Scoped to explicit legacy versions (never a lexical '< 2.1', which breaks on a future major
+-- version) and to THIS run: a malformed 2.1 run that published no area rows must fail VAL-18,
+-- not be quietly re-dressed as a legacy product. An older producer's historical 2.1 area rows
+-- do not suppress the fallback for a current 2.0 run from the same producer, because the
+-- existence check is scoped to v.run_id, not to the producer as a whole.
+WHERE v.payload_schema_version IN ('1.0', '2.0')
+  AND NOT EXISTS (
     SELECT 1
     FROM {db}.validation_area AS a
     WHERE a.product_prefix = v.product_prefix
       AND a.producer_id    = v.producer_id
+      AND a.run_id         = v.run_id
 );
 
 COMMENT ON VIEW {db}.validation_trust_map IS
-'Trust map - latest entry per product, producer and area, with coverage derived on read. Read the areas a query touches, proceed, and disclose their confidence and gaps. Nothing here withholds use of the product.';
+'Trust map - latest entry per product, producer and area; coverage and staleness derived on read against the evidence''s own run. Read the areas a query touches, proceed, and disclose confidence and gaps. Nothing here withholds use.';
 
 -- The authoritative map is the set of rows whose producer_id matches the trust-authoritative
 -- producer designated in the product's orientation metadata; other producers' rows are evidence.

--- a/implementation/teradata/patterns/validation/README.md
+++ b/implementation/teradata/patterns/validation/README.md
@@ -3,7 +3,7 @@ title: Teradata Validation Pattern Implementation
 anchor: validation
 type: implementation
 status: standard
-version: 2.0
+version: 2.1
 normative: true
 implements: validation
 platform: teradata
@@ -11,29 +11,38 @@ platform: teradata
 
 # Teradata: Validation Implementation
 
-Teradata binding of [`design/patterns/validation.md`](../../../../design/patterns/validation.md). Validation results are operational evidence and live in the **Observability** module, alongside its other run/event tables. Wire schema 2.0 is canonical; 1.0 is a registered legacy binding.
+Teradata binding of [`design/patterns/validation.md`](../../../../design/patterns/validation.md). Validation results are operational evidence and live in the **Observability** module, alongside its other run/event tables. Wire schema 2.1 is canonical (additive over 2.0); 1.0 is a registered legacy binding.
 
 ## Files
 
 | File | Purpose |
 |------|---------|
-| `01-validation-run.sql` | The `validation_run` append-only history table (profile `EVENT_APPEND_ONLY`) and its statistics. |
-| `02-views.sql` | `validation_latest`: the latest-per-(product, producer) gate/evidence projection. |
-| `consumer-queries.sql` | Gate check before analytical use, all-producer evidence summary, run-history trend. |
-| `conformance-queries.sql` | `DBC`/data checks for the VAL conformance rules. |
+| `01-validation-run.sql` | The `validation_run` append-only history table (profile `EVENT_APPEND_ONLY`) and its statistics: the run-level summary. |
+| `02-views.sql` | `validation_latest`: the latest-per-(product, producer) run projection. |
+| `03-validation-area.sql` | The `validation_area` append-only trust map: one row per run per area, with its vocabularies CHECK-constrained. |
+| `04-trust-map-views.sql` | `validation_trust_map`: the latest entry per (product, producer, area), coverage derived on read, plus the derived `PRODUCT` entry for a 2.0 producer. |
+| `consumer-queries.sql` | The map read before analytical use, the whole map, the most-cautious composite, evidence age, advisory summary, failure detail, per-area and run trends. |
+| `conformance-queries.sql` | `DBC`/data checks for the VAL conformance rules. `{sem}` tags the product's Semantic container where an `ENTITY` scope is resolved. |
+
+Deploy in file order: the views project the tables above them.
 
 ## Type bindings
 
 | Contract element | Teradata binding |
 |------------------|------------------|
-| `*_dts` run instants | `TIMESTAMP(6) WITH TIME ZONE`, persisted UTC (schema 2.0: typed, so latest-run ordering is chronological). |
-| `agent_use_allowed` | `BYTEINT` 0/1, CHECK-constrained. |
+| `*_dts` run instants | `TIMESTAMP(6) WITH TIME ZONE`, persisted UTC (schema 2.0 onward: typed, so latest-run ordering is chronological). |
+| `agent_use_allowed` | `BYTEINT` 0/1, CHECK-constrained. Deprecated at 2.1: published as 1, never read. |
 | Scores | `INTEGER` nullable (null = not assessed). |
 | JSON blobs | `JSON(32000) CHARACTER SET UNICODE`, cap discipline applied before truncation. |
+| `scope_kind`, `area_status`, `confidence` | `VARCHAR` CHARACTER SET LATIN with a CHECK constraint per closed vocabulary, so an invalid value fails at insert rather than at read. |
+| `open_gaps`, `recommended_action` | `VARCHAR(1000) CHARACTER SET UNICODE`: prose an agent reports verbatim. |
+| Coverage ratio | Derived in `validation_trust_map` as `DECIMAL(9,4)`, never stored: one copy of the fact. |
 
 ## Publish semantics
 
-Append, never replace: each run inserts exactly one row (VAL-09). `run_id` is deterministic (first 32 hex of a SHA-256 over `prefix|producer_id|started_iso|completed_iso|result_count`). Consumers read through `LOCKING ROW FOR ACCESS` views, never the base table. The product-level gate is the row whose `producer_id` matches the gate-authoritative producer designated in the product's orientation metadata; other rows are evidence.
+Append, never replace: each run inserts exactly one `validation_run` row (VAL-09) and one `validation_area` row per area its profile covers, including the areas it could not check (VAL-18). `run_id` is deterministic (first 32 hex of a SHA-256 over `prefix|producer_id|started_iso|completed_iso|result_count`) and is what ties the area rows to their run. Consumers read through `LOCKING ROW FOR ACCESS` views, never the base tables.
+
+The authoritative map is the set of rows whose `producer_id` matches the trust-authoritative producer designated in the product's orientation metadata; other producers' rows are evidence. Nothing in either relation withholds use of the product: a consumer reads the areas it is about to query, proceeds, and discloses their confidence and gaps.
 
 ## Legacy binding (wire schema 1.0)
 
@@ -41,9 +50,14 @@ Append, never replace: each run inserts exactly one row (VAL-09). `run_id` is de
 
 ## Check sources lifted into validator profiles
 
-| Source | Checks | Category / severity |
-|--------|--------|---------------------|
-| Temporal & lifecycle pattern | TLM-04/05/06 dictionary; TLM-08/09/10/11 data invariants | STRUCTURAL / blocking → CRITICAL |
-| Semantic module | Orphan modules, missing objects, invalid roles, kind mismatches, duplicate registrations | SEMANTIC / STRUCTURAL, ERROR-CRITICAL |
-| Object-placement pattern | Container and naming conformance | STRUCTURAL, WARNING-ERROR |
-| Each module's `INV-*` checks | The per-module `validation.sql.j2` invariant checks | per the module |
+Scope comes from ownership: a check belongs to the area of the document or directory that states it, so these suites acquire their scope without being rewritten (design §12).
+
+| Source | Checks | Category / severity | Area |
+|--------|--------|---------------------|------|
+| Temporal & lifecycle pattern | TLM-04/05/06 dictionary; TLM-08/09/10/11 data invariants | STRUCTURAL / `[B]` → CRITICAL | `PATTERN:temporal-lifecycle-metadata`, or the entity a data check resolves |
+| Semantic module | Orphan modules, missing objects, invalid roles, kind mismatches, duplicate registrations | SEMANTIC / STRUCTURAL, ERROR-CRITICAL | `MODULE:semantic` |
+| Object-placement pattern | Container and naming conformance | STRUCTURAL, WARNING-ERROR | `PATTERN:object-placement` |
+| Each module's `INV-*` checks | The per-module `validation.sql.j2` invariant checks | per the module | `MODULE:{module}` |
+| This pattern's own conformance queries | The VAL rules above | STRUCTURAL, ERROR | `PATTERN:validation` |
+
+An area whose only check is unwritten is published at `checks_expected = 0`, which reads as `no-evidence`: Observability, object-placement and physical-storage ship none today, and the map is where that becomes visible rather than assumed clean.

--- a/implementation/teradata/patterns/validation/README.md
+++ b/implementation/teradata/patterns/validation/README.md
@@ -20,9 +20,9 @@ Teradata binding of [`design/patterns/validation.md`](../../../../design/pattern
 | `01-validation-run.sql` | The `validation_run` append-only history table (profile `EVENT_APPEND_ONLY`) and its statistics: the run-level summary. |
 | `02-views.sql` | `validation_latest`: the latest-per-(product, producer) run projection. |
 | `03-validation-area.sql` | The `validation_area` append-only trust map: one row per run per area, with its vocabularies CHECK-constrained. |
-| `04-trust-map-views.sql` | `validation_trust_map`: the latest entry per (product, producer, area), coverage derived on read, plus the derived `PRODUCT` entry for a 2.0 producer. |
-| `consumer-queries.sql` | The map read before analytical use, the whole map, the most-cautious composite, evidence age, advisory summary, failure detail, per-area and run trends. |
-| `conformance-queries.sql` | `DBC`/data checks for the VAL conformance rules. `{sem}` tags the product's Semantic container where an `ENTITY` scope is resolved. |
+| `04-trust-map-views.sql` | `validation_trust_map`: the latest entry per (product, producer, area), coverage and staleness derived on read against each area's own run, plus the derived `PRODUCT` entry for a 2.0/1.0 producer. |
+| `consumer-queries.sql` | The map read before analytical use (reconciled against the caller's requested scopes, so a missing area reads as explicit `no-evidence` rather than disappearing), the whole map, the most-cautious composite, run-level evidence-age context, advisory summary, failure detail, per-area and run trends. |
+| `conformance-queries.sql` | `DBC`/data checks for the VAL conformance rules. `{sem}` tags the product's Semantic container where `PRODUCT`, `MODULE`, and `ENTITY` scopes are resolved; `PATTERN`/`CAPABILITY` have no deployed catalogue and are a producer build-time assertion instead. |
 
 Deploy in file order: the views project the tables above them.
 

--- a/implementation/teradata/patterns/validation/README.md
+++ b/implementation/teradata/patterns/validation/README.md
@@ -44,6 +44,19 @@ Append, never replace: each run inserts exactly one `validation_run` row (VAL-09
 
 The authoritative map is the set of rows whose `producer_id` matches the trust-authoritative producer designated in the product's orientation metadata; other producers' rows are evidence. Nothing in either relation withholds use of the product: a consumer reads the areas it is about to query, proceeds, and discloses their confidence and gaps.
 
+## Regression tests
+
+The read path is logic, and the review of this pattern's #57 revision found three defects in it that inspection had missed: staleness graded against the wrong run, a legacy fallback that swallowed a malformed run, and a requested area that vanished instead of reporting itself unknown. [`tooling/validation/tests/test_trust_map.py`](../../../../tooling/validation/tests/test_trust_map.py) states each as a behaviour and executes it:
+
+```bash
+python -m unittest discover -s tooling/validation/tests
+```
+
+The SQL is **read from the files in this directory**, never retyped, and translated onto stdlib `sqlite3` by [`td_sqlite.py`](../../../../tooling/validation/tests/td_sqlite.py) so nothing in `tooling/` needs a live platform. Reverting a fix here fails those tests. Two consequences worth knowing before changing anything in this directory:
+
+- **A new Teradata construct breaks the harness loudly.** The translator handles an explicit, narrow set of rewrites and raises `UntranslatedSql` on anything else, rather than dropping the clause it was load-bearing in. Extend it in the same commit.
+- **It does not test Teradata's semantics.** `QUALIFY` becomes a wrapped `ROW_NUMBER`, `INTERVAL` becomes date arithmetic, and a zone-qualified timestamp becomes ISO text: faithful for the comparisons the map makes, not in general. Platform conformance stays `conformance-queries.sql` run against the deployed product; the suite is the net underneath it.
+
 ## Legacy binding (wire schema 1.0)
 
 1.0 publishes the same status/count/score/JSON columns without the producer-identity, `source_format`, `payload_schema_version`, or audit columns, with run timestamps as `VARCHAR(40)` ISO-8601 (`started_at`/`completed_at`) under producer-specific object names in the **Semantic** module (`trust_engine_run` / `trust_engine_latest`). Migration is a re-publish (start inserting into `validation_run` with identity populated; repoint orientation), not a rename.

--- a/implementation/teradata/patterns/validation/conformance-queries.sql
+++ b/implementation/teradata/patterns/validation/conformance-queries.sql
@@ -9,9 +9,14 @@ WHERE trust_status NOT IN ('TRUSTED', 'DEGRADED', 'UNTRUSTED');
 
 -- VAL-02: agent_use_allowed is deprecated at 2.1 and published as go. It is retained only so a
 -- 2.0 reader still parses the record; consumers branch on the trust map, never on this field.
+-- "At the canonical schema or later" is expressed by excluding the registered legacy versions,
+-- never as a lexical comparison against '2.1': payload_schema_version is a string, so '10.0'
+-- sorts below '2.1' and a future major version would silently fall out of every check below.
+-- The list is the same one the trust map's legacy fallback uses (04-trust-map-views.sql), so a
+-- newly registered legacy binding is added in exactly two places.
 SELECT run_id, producer_id, payload_schema_version, agent_use_allowed
 FROM {db}.validation_run
-WHERE payload_schema_version >= '2.1'
+WHERE payload_schema_version NOT IN ('1.0', '2.0')
   AND agent_use_allowed <> 1;
 
 -- VAL-04: run check totals reconcile
@@ -146,12 +151,13 @@ WHERE NOT EXISTS (
           AND r.run_id         = a.run_id
       );
 
--- VAL-18 (every 2.1 run publishes at least one area entry - not only a run with failures.
--- Without this, a malformed 2.1 producer that publishes zero area rows is silently re-dressed
--- as a legacy product by the trust map's schema 2.0/1.0 fallback (04-trust-map-views.sql).)
+-- VAL-18 (every canonical-schema run publishes at least one area entry - not only a run with
+-- failures. Without this, a malformed 2.1 producer that publishes zero area rows is silently
+-- re-dressed as a legacy product by the trust map's schema 2.0/1.0 fallback
+-- (04-trust-map-views.sql).)
 SELECT r.run_id, r.producer_id, r.payload_schema_version
 FROM {db}.validation_run AS r
-WHERE r.payload_schema_version = '2.1'
+WHERE r.payload_schema_version NOT IN ('1.0', '2.0')
   AND NOT EXISTS (
         SELECT 1
         FROM {db}.validation_area AS a
@@ -163,7 +169,7 @@ WHERE r.payload_schema_version = '2.1'
 -- VAL-18 (a run that found failures publishes somewhere for them to land)
 SELECT r.run_id, r.producer_id, r.failed_count, r.error_count
 FROM {db}.validation_run AS r
-WHERE r.payload_schema_version >= '2.1'
+WHERE r.payload_schema_version NOT IN ('1.0', '2.0')
   AND r.failed_count + r.error_count > 0
   AND NOT EXISTS (
         SELECT 1

--- a/implementation/teradata/patterns/validation/conformance-queries.sql
+++ b/implementation/teradata/patterns/validation/conformance-queries.sql
@@ -2,17 +2,31 @@
 -- Each query must return ZERO rows for a conforming deployment.
 -- {db} is a generic tag, e.g. {Product}_Observability.
 
--- VAL-01/02: vocabulary and status/decision agreement
-SELECT run_id, producer_id, trust_status, agent_use_allowed
+-- VAL-01: status vocabulary
+SELECT run_id, producer_id, trust_status
 FROM {db}.validation_run
-WHERE trust_status NOT IN ('TRUSTED', 'DEGRADED', 'UNTRUSTED')
-   OR (trust_status IN ('TRUSTED', 'DEGRADED') AND agent_use_allowed <> 1)
-   OR (trust_status = 'UNTRUSTED' AND agent_use_allowed <> 0);
+WHERE trust_status NOT IN ('TRUSTED', 'DEGRADED', 'UNTRUSTED');
 
--- VAL-04: check totals reconcile
+-- VAL-02: agent_use_allowed is deprecated at 2.1 and published as go. It is retained only so a
+-- 2.0 reader still parses the record; consumers branch on the trust map, never on this field.
+SELECT run_id, producer_id, payload_schema_version, agent_use_allowed
+FROM {db}.validation_run
+WHERE payload_schema_version >= '2.1'
+  AND agent_use_allowed <> 1;
+
+-- VAL-04: run check totals reconcile
 SELECT run_id, producer_id, total_checks, passed_count, failed_count, error_count
 FROM {db}.validation_run
 WHERE total_checks <> passed_count + failed_count + error_count;
+
+-- VAL-05: severity counts cannot exceed the failures they classify, on either relation
+SELECT run_id, producer_id, critical_failure_count, error_failure_count, failed_count, error_count
+FROM {db}.validation_run
+WHERE critical_failure_count + error_failure_count > failed_count + error_count;
+
+SELECT run_id, producer_id, scope_kind, scope_id
+FROM {db}.validation_area
+WHERE critical_failure_count + error_failure_count > failed_count + error_count;
 
 -- VAL-06: score ranges
 SELECT run_id, producer_id
@@ -28,8 +42,96 @@ WHERE producer_id IS NULL
    OR TRIM(producer_id) = ''
    OR payload_schema_version IS NULL;
 
--- Deployment: the latest view yields one row per (product, producer)
+-- VAL-14: area vocabularies. The CHECK constraints on validation_area enforce the three closed
+-- vocabularies at insert; this catches a scope_id that names nothing, which no constraint can.
+SELECT a.run_id, a.scope_kind, a.scope_id
+FROM {db}.validation_area AS a
+WHERE TRIM(a.scope_id) = '';
+
+-- VAL-14 (ENTITY scope is module-qualified, e.g. 'domain.Ticket')
+SELECT a.run_id, a.scope_kind, a.scope_id
+FROM {db}.validation_area AS a
+WHERE a.scope_kind = 'ENTITY'
+  AND POSITION('.' IN a.scope_id) = 0;
+
+-- VAL-14 (ENTITY scope resolves): every entity-scoped area names a catalogued entity.
+-- {sem} is the product's Semantic container, e.g. {Product}_Semantic.
+SELECT a.run_id, a.scope_kind, a.scope_id
+FROM {db}.validation_area AS a
+WHERE a.scope_kind = 'ENTITY'
+  AND POSITION('.' IN a.scope_id) > 0
+  AND NOT EXISTS (
+        SELECT 1
+        FROM {sem}.entity_metadata AS e
+        WHERE UPPER(e.module_name) = UPPER(SUBSTRING(a.scope_id FROM 1
+                                            FOR POSITION('.' IN a.scope_id) - 1))
+          AND UPPER(e.entity_name) = UPPER(SUBSTRING(a.scope_id FROM
+                                            POSITION('.' IN a.scope_id) + 1))
+      );
+
+-- VAL-15: per-area counts reconcile, and coverage cannot exceed what the profile defines
+SELECT run_id, producer_id, scope_kind, scope_id, checks_ran, checks_expected
+FROM {db}.validation_area
+WHERE checks_ran <> passed_count + failed_count + error_count
+   OR checks_ran > checks_expected
+   OR checks_ran < 0
+   OR checks_expected < 0;
+
+-- VAL-16: status and confidence agree with coverage. A pass claims full coverage of checks that
+-- ran; an area nothing reached is 'unknown', never 'fine'.
+SELECT run_id, producer_id, scope_kind, scope_id, area_status, confidence, checks_ran, checks_expected
+FROM {db}.validation_area
+WHERE (area_status = 'pass'         AND (checks_ran = 0 OR checks_ran <> checks_expected))
+   OR (confidence  = 'strong'      AND (checks_ran = 0 OR checks_ran <> checks_expected
+                                         OR failed_count + error_count > 0))
+   OR (area_status = 'no-evidence'   AND (checks_expected <> 0 OR confidence <> 'unknown'))
+   OR (area_status = 'not-validated' AND (checks_ran <> 0 OR confidence <> 'unknown'))
+   OR (area_status = 'fail'          AND failed_count + error_count = 0)
+   OR (failed_count + error_count > 0 AND area_status <> 'fail')
+   OR (critical_failure_count + error_failure_count > 0 AND confidence NOT IN ('weak', 'unknown'))
+   -- VAL-03: coverage below half is 'weak' by default, and the default is never loosened
+   OR (confidence = 'partial' AND checks_expected > 0 AND checks_ran * 2 < checks_expected);
+
+-- VAL-17: every entry below 'strong' says what is missing and what would raise it
+SELECT run_id, producer_id, scope_kind, scope_id, confidence
+FROM {db}.validation_area
+WHERE confidence <> 'strong'
+  AND (open_gaps IS NULL OR TRIM(open_gaps) = ''
+       OR recommended_action IS NULL OR TRIM(recommended_action) = '');
+
+-- VAL-18: every area entry belongs to a published run (the converse - every area the profile
+-- covers has an entry - is a producer-side assertion; a consumer cannot see the profile).
+SELECT a.run_id, a.producer_id, a.scope_kind, a.scope_id
+FROM {db}.validation_area AS a
+WHERE NOT EXISTS (
+        SELECT 1
+        FROM {db}.validation_run AS r
+        WHERE r.product_prefix = a.product_prefix
+          AND r.producer_id    = a.producer_id
+          AND r.run_id         = a.run_id
+      );
+
+-- VAL-18 (a run that found failures publishes somewhere for them to land)
+SELECT r.run_id, r.producer_id, r.failed_count, r.error_count
+FROM {db}.validation_run AS r
+WHERE r.payload_schema_version >= '2.1'
+  AND r.failed_count + r.error_count > 0
+  AND NOT EXISTS (
+        SELECT 1
+        FROM {db}.validation_area AS a
+        WHERE a.product_prefix = r.product_prefix
+          AND a.producer_id    = r.producer_id
+          AND a.run_id         = r.run_id
+          AND a.area_status    = 'fail'
+      );
+
+-- Deployment: the latest views yield one row per (product, producer) and per area
 SELECT product_prefix, producer_id, COUNT(*) AS rows_seen
 FROM {db}.validation_latest
 GROUP BY product_prefix, producer_id
+HAVING COUNT(*) > 1;
+
+SELECT product_prefix, producer_id, scope_kind, scope_id, COUNT(*) AS rows_seen
+FROM {db}.validation_trust_map
+GROUP BY product_prefix, producer_id, scope_kind, scope_id
 HAVING COUNT(*) > 1;

--- a/implementation/teradata/patterns/validation/conformance-queries.sql
+++ b/implementation/teradata/patterns/validation/conformance-queries.sql
@@ -35,6 +35,16 @@ WHERE data_product_trust_score    NOT BETWEEN 0 AND 100
    OR performance_readiness_score NOT BETWEEN 0 AND 100
    OR operational_readiness_score NOT BETWEEN 0 AND 100;
 
+-- VAL-09: an area's completed_dts is inherited from its parent run, so latest-per-area ordering
+-- matches latest-per-run and the trust map's staleness join (04-trust-map-views.sql) is sound.
+SELECT a.run_id, a.producer_id, a.scope_kind, a.scope_id, a.completed_dts, r.completed_dts AS run_completed_dts
+FROM {db}.validation_area AS a
+INNER JOIN {db}.validation_run AS r
+        ON  r.product_prefix = a.product_prefix
+        AND r.producer_id    = a.producer_id
+        AND r.run_id         = a.run_id
+WHERE a.completed_dts <> r.completed_dts;
+
 -- VAL-12: producer identity present (canonical schema)
 SELECT run_id
 FROM {db}.validation_run
@@ -44,6 +54,8 @@ WHERE producer_id IS NULL
 
 -- VAL-14: area vocabularies. The CHECK constraints on validation_area enforce the three closed
 -- vocabularies at insert; this catches a scope_id that names nothing, which no constraint can.
+-- Resolvable here for PRODUCT, MODULE and ENTITY against deployed catalogue metadata; PATTERN
+-- and CAPABILITY have no such catalogue and are a producer build-time assertion instead (§14).
 SELECT a.run_id, a.scope_kind, a.scope_id
 FROM {db}.validation_area AS a
 WHERE TRIM(a.scope_id) = '';
@@ -68,6 +80,29 @@ WHERE a.scope_kind = 'ENTITY'
           AND UPPER(e.entity_name) = UPPER(SUBSTRING(a.scope_id FROM
                                             POSITION('.' IN a.scope_id) + 1))
       );
+
+-- VAL-14 (MODULE scope resolves): every module-scoped area names a module the product actually
+-- deployed. {sem} is the product's Semantic container, e.g. {Product}_Semantic.
+SELECT a.run_id, a.scope_kind, a.scope_id
+FROM {db}.validation_area AS a
+WHERE a.scope_kind = 'MODULE'
+  AND NOT EXISTS (
+        SELECT 1
+        FROM {sem}.data_product_map AS dm
+        WHERE dm.is_active = 1
+          AND UPPER(dm.module_name) = UPPER(a.scope_id)
+      );
+
+-- VAL-14 (PRODUCT scope resolves): a PRODUCT-scoped area names this product, not another one.
+SELECT a.run_id, a.scope_kind, a.scope_id
+FROM {db}.validation_area AS a
+WHERE a.scope_kind = 'PRODUCT'
+  AND a.scope_id <> a.product_prefix;
+
+-- VAL-14 (PATTERN, CAPABILITY): these vocabularies have no deployed catalogue a consumer can
+-- resolve against, so a typo'd scope_id (e.g. 'CAPABILITY:reposrting') is caught only by the
+-- producer's own build-time assertion against its validator profile - not runtime SQL, which
+-- cannot see the profile. See design/patterns/validation.md §14 (VAL-14) for the split.
 
 -- VAL-15: per-area counts reconcile, and coverage cannot exceed what the profile defines
 SELECT run_id, producer_id, scope_kind, scope_id, checks_ran, checks_expected
@@ -109,6 +144,20 @@ WHERE NOT EXISTS (
         WHERE r.product_prefix = a.product_prefix
           AND r.producer_id    = a.producer_id
           AND r.run_id         = a.run_id
+      );
+
+-- VAL-18 (every 2.1 run publishes at least one area entry - not only a run with failures.
+-- Without this, a malformed 2.1 producer that publishes zero area rows is silently re-dressed
+-- as a legacy product by the trust map's schema 2.0/1.0 fallback (04-trust-map-views.sql).)
+SELECT r.run_id, r.producer_id, r.payload_schema_version
+FROM {db}.validation_run AS r
+WHERE r.payload_schema_version = '2.1'
+  AND NOT EXISTS (
+        SELECT 1
+        FROM {db}.validation_area AS a
+        WHERE a.product_prefix = r.product_prefix
+          AND a.producer_id    = r.producer_id
+          AND a.run_id         = r.run_id
       );
 
 -- VAL-18 (a run that found failures publishes somewhere for them to land)

--- a/implementation/teradata/patterns/validation/consumer-queries.sql
+++ b/implementation/teradata/patterns/validation/consumer-queries.sql
@@ -1,7 +1,7 @@
 -- Validation: consumer queries (Teradata). Binding of the consumption contract, trust authority,
 -- and staleness rules in design/patterns/validation.md §9, §11.
 -- {db} is a generic tag, e.g. {Product}_Observability. :trust_producer comes from orientation
--- (trust_authoritative_producer; gate_authoritative_producer is the legacy spelling).
+-- (trust_authoritative_producer).
 --
 -- Nothing below withholds use of the product. The map says how far to trust each area and what
 -- would raise it; the consumer proceeds and reports what it read (§9: read, select, proceed, disclose).

--- a/implementation/teradata/patterns/validation/consumer-queries.sql
+++ b/implementation/teradata/patterns/validation/consumer-queries.sql
@@ -7,34 +7,44 @@
 -- would raise it; the consumer proceeds and reports what it read (§9: read, select, proceed, disclose).
 
 -- 1. The areas this query plan touches, read BEFORE analytical use.
--- :scope_keys is the set of 'KIND:id' keys the plan reaches - the modules, entities, patterns and
--- capabilities behind the objects resolved through AccessObject ('MODULE:domain',
--- 'ENTITY:domain.Ticket'). Concatenated rather than a two-column IN list, which Teradata does not
--- take as a literal row constructor. Take the narrowest entry that covers each.
+-- requested_validation_scope is a request-scoped relation (e.g. a volatile table) the caller
+-- populates with one (scope_kind, scope_id) row per module, entity, pattern or capability the
+-- plan reaches - the areas behind the objects resolved through AccessObject
+-- (('MODULE', 'domain'), ('ENTITY', 'domain.Ticket')). Kept as two columns rather than a
+-- concatenated 'KIND:id' key so the join uses real column statistics, not a computed string.
+-- Driving FROM the caller's own request (LEFT OUTER JOIN to the map, not the map filtered by the
+-- request) is what guarantees every requested area gets a row: a plain filter silently drops a
+-- scope the map has no entry for, which is the exact failure mode the trust map exists to remove.
 -- Rules: a row missing for an area means no-evidence / unknown, not sound;
--- a row whose evidence is stale reads at confidence 'unknown' whatever it recorded (query 4);
+-- a row whose evidence is stale reads at confidence 'unknown' whatever it recorded;
 -- never recount the run's capped JSON blobs.
-SELECT m.scope_kind
-     , m.scope_id
-     , m.area_status
-     , m.confidence
+SELECT s.scope_kind
+     , s.scope_id
+     , COALESCE(m.area_status, 'no-evidence') AS area_status
+     , COALESCE(m.confidence, 'unknown') AS confidence
+     , m.recorded_confidence
+     , COALESCE(m.evidence_is_stale, 0) AS evidence_is_stale
      , m.checks_ran
      , m.checks_expected
      , m.coverage_ratio
      , m.critical_failure_count
      , m.error_failure_count
-     , m.open_gaps
-     , m.recommended_action
-     , m.map_source
+     , COALESCE(m.open_gaps,
+           'No trust-map entry was published for an area used by this query.') AS open_gaps
+     , COALESCE(m.recommended_action,
+           'Add this area to the validator profile and publish a validation_area entry.') AS recommended_action
+     , COALESCE(m.map_source, 'NONE') AS map_source
      , m.completed_dts
-FROM {db}.validation_trust_map AS m
-WHERE m.product_prefix = :product_prefix
-  AND m.producer_id    = :trust_producer
-  AND m.scope_kind || ':' || m.scope_id IN (:scope_keys)
-ORDER BY CASE m.confidence WHEN 'unknown' THEN 1 WHEN 'weak' THEN 2
-                           WHEN 'partial' THEN 3 ELSE 4 END
-       , m.scope_kind
-       , m.scope_id;
+FROM requested_validation_scope AS s
+LEFT OUTER JOIN {db}.validation_trust_map AS m
+             ON  m.product_prefix = :product_prefix
+             AND m.producer_id    = :trust_producer
+             AND m.scope_kind     = s.scope_kind
+             AND m.scope_id       = s.scope_id
+ORDER BY CASE COALESCE(m.confidence, 'unknown')
+              WHEN 'unknown' THEN 1 WHEN 'weak' THEN 2 WHEN 'partial' THEN 3 ELSE 4 END
+       , s.scope_kind
+       , s.scope_id;
 
 -- 2. The whole map, for orientation and for reporting where a product is strong and where it is not.
 SELECT m.scope_kind
@@ -61,18 +71,16 @@ WHERE m.product_prefix = :product_prefix
 GROUP BY m.scope_kind, m.scope_id
 ORDER BY lowest_confidence_rank, m.scope_kind, m.scope_id;
 
--- 4. Evidence age for the authoritative map: staleness downgrades confidence to 'unknown'
--- and is disclosed with its date. It never blocks. The window is the producer's declared
--- expiry, else the product's declared maximum age, else 7 days from completed_dts.
+-- 4. Evidence age for the producer's most recent run, for run-history context only. Staleness
+-- that governs what a consumer may say about an AREA is already folded into query 1/2's
+-- confidence and evidence_is_stale columns, evaluated against each area's own run (§11) - do not
+-- recompute it from this producer-latest row, which can be newer than the area actually read.
 SELECT v.producer_id
      , v.completed_dts
      , v.evidence_expires_dts
      , v.payload_schema_version
-     , CASE WHEN v.evidence_expires_dts IS NOT NULL
-              AND v.evidence_expires_dts < CURRENT_TIMESTAMP(6)                     THEN 1
-            WHEN v.evidence_expires_dts IS NULL
-              AND v.completed_dts < CURRENT_TIMESTAMP(6) - INTERVAL '7' DAY          THEN 1
-            ELSE 0
+     , CASE WHEN COALESCE(v.evidence_expires_dts, v.completed_dts + INTERVAL '7' DAY)
+                < CURRENT_TIMESTAMP(6) THEN 1 ELSE 0
        END AS evidence_is_stale
 FROM {db}.validation_latest AS v
 WHERE v.product_prefix = :product_prefix

--- a/implementation/teradata/patterns/validation/consumer-queries.sql
+++ b/implementation/teradata/patterns/validation/consumer-queries.sql
@@ -1,36 +1,121 @@
--- Validation: consumer queries (Teradata). Binding of the consumption contract, gate authority, and staleness rules in design/patterns/validation.md.
--- {db} is a generic tag, e.g. {Product}_Observability. :gate_producer comes from orientation.
+-- Validation: consumer queries (Teradata). Binding of the consumption contract, trust authority,
+-- and staleness rules in design/patterns/validation.md §9, §11.
+-- {db} is a generic tag, e.g. {Product}_Observability. :trust_producer comes from orientation
+-- (trust_authoritative_producer; gate_authoritative_producer is the legacy spelling).
+--
+-- Nothing below withholds use of the product. The map says how far to trust each area and what
+-- would raise it; the consumer proceeds and reports what it read (§9: read, select, proceed, disclose).
 
--- Product gate check BEFORE analytical use.
--- Rules: a missing gate row means unvalidated (stop for autonomous use); a row past
--- evidence_expires_dts (or older than the applicable window, default 7 days from
--- completed_dts) is stale (treat as agent_use_allowed = 0); never recount the JSON
--- blobs; never proceed on UNTRUSTED.
-SELECT v.trust_status
-     , v.agent_use_allowed
+-- 1. The areas this query plan touches, read BEFORE analytical use.
+-- :scope_keys is the set of 'KIND:id' keys the plan reaches - the modules, entities, patterns and
+-- capabilities behind the objects resolved through AccessObject ('MODULE:domain',
+-- 'ENTITY:domain.Ticket'). Concatenated rather than a two-column IN list, which Teradata does not
+-- take as a literal row constructor. Take the narrowest entry that covers each.
+-- Rules: a row missing for an area means no-evidence / unknown, not sound;
+-- a row whose evidence is stale reads at confidence 'unknown' whatever it recorded (query 4);
+-- never recount the run's capped JSON blobs.
+SELECT m.scope_kind
+     , m.scope_id
+     , m.area_status
+     , m.confidence
+     , m.checks_ran
+     , m.checks_expected
+     , m.coverage_ratio
+     , m.critical_failure_count
+     , m.error_failure_count
+     , m.open_gaps
+     , m.recommended_action
+     , m.map_source
+     , m.completed_dts
+FROM {db}.validation_trust_map AS m
+WHERE m.product_prefix = :product_prefix
+  AND m.producer_id    = :trust_producer
+  AND m.scope_kind || ':' || m.scope_id IN (:scope_keys)
+ORDER BY CASE m.confidence WHEN 'unknown' THEN 1 WHEN 'weak' THEN 2
+                           WHEN 'partial' THEN 3 ELSE 4 END
+       , m.scope_kind
+       , m.scope_id;
+
+-- 2. The whole map, for orientation and for reporting where a product is strong and where it is not.
+SELECT m.scope_kind
+     , m.scope_id
+     , m.area_status
+     , m.confidence
+     , m.coverage_ratio
+     , m.open_gaps
+     , m.recommended_action
+FROM {db}.validation_trust_map AS m
+WHERE m.product_prefix = :product_prefix
+  AND m.producer_id    = :trust_producer
+ORDER BY m.scope_kind, m.scope_id;
+
+-- 3. No designated producer: take the most cautious entry per area, and say that you did.
+-- (§9 trust authority. A product with two maps and no designation has not said which it means.)
+SELECT m.scope_kind
+     , m.scope_id
+     , MIN(CASE m.confidence WHEN 'unknown' THEN 1 WHEN 'weak' THEN 2
+                             WHEN 'partial' THEN 3 ELSE 4 END) AS lowest_confidence_rank
+     , COUNT(DISTINCT m.confidence) AS producers_disagree
+FROM {db}.validation_trust_map AS m
+WHERE m.product_prefix = :product_prefix
+GROUP BY m.scope_kind, m.scope_id
+ORDER BY lowest_confidence_rank, m.scope_kind, m.scope_id;
+
+-- 4. Evidence age for the authoritative map: staleness downgrades confidence to 'unknown'
+-- and is disclosed with its date. It never blocks. The window is the producer's declared
+-- expiry, else the product's declared maximum age, else 7 days from completed_dts.
+SELECT v.producer_id
      , v.completed_dts
      , v.evidence_expires_dts
-     , v.critical_failure_count
-     , v.error_failure_count
-     , v.data_product_trust_score
+     , v.payload_schema_version
+     , CASE WHEN v.evidence_expires_dts IS NOT NULL
+              AND v.evidence_expires_dts < CURRENT_TIMESTAMP(6)                     THEN 1
+            WHEN v.evidence_expires_dts IS NULL
+              AND v.completed_dts < CURRENT_TIMESTAMP(6) - INTERVAL '7' DAY          THEN 1
+            ELSE 0
+       END AS evidence_is_stale
 FROM {db}.validation_latest AS v
 WHERE v.product_prefix = :product_prefix
-  AND v.producer_id = :gate_producer;
+  AND v.producer_id    = :trust_producer;
 
--- All-producer evidence summary (surface disagreements).
-SELECT v.producer_id
-     , v.producer_version
-     , v.source_format
-     , v.trust_status
-     , v.agent_use_allowed
-     , v.completed_dts
+-- 5. Advisory product summary (§4.4). A first glance, not permission: agent_use_allowed is
+-- deprecated at schema 2.1 and no consumer branches on it.
+SELECT v.trust_status
+     , v.data_product_trust_score
+     , v.performance_readiness_score
+     , v.operational_readiness_score
      , v.total_checks
      , v.failed_count
+     , v.error_count
+     , v.completed_dts
 FROM {db}.validation_latest AS v
 WHERE v.product_prefix = :product_prefix
-ORDER BY v.producer_id;
+  AND v.producer_id    = :trust_producer;
 
--- Run-history trend (auditors).
+-- 6. Failed-check detail for an area a consumer intends to use, so the disclosure names the defect
+-- rather than only its severity. The capped blob carries scope_kind / scope_id per item (schema 2.1).
+SELECT v.producer_id
+     , v.completed_dts
+     , v.failed_checks_json
+     , v.repair_candidate_count
+FROM {db}.validation_latest AS v
+WHERE v.product_prefix = :product_prefix
+  AND v.producer_id    = :trust_producer;
+
+-- 7. Per-area trend (auditors, and product owners closing coverage gaps).
+SELECT a.scope_kind
+     , a.scope_id
+     , a.completed_dts
+     , a.area_status
+     , a.confidence
+     , a.checks_ran
+     , a.checks_expected
+FROM {db}.validation_area AS a
+WHERE a.product_prefix = :product_prefix
+  AND a.producer_id    = :trust_producer
+ORDER BY a.scope_kind, a.scope_id, a.completed_dts DESC;
+
+-- 8. Run-history trend (auditors).
 SELECT r.producer_id
      , r.completed_dts
      , r.trust_status

--- a/prompts/Access_Data_Product_Starter.md
+++ b/prompts/Access_Data_Product_Starter.md
@@ -29,6 +29,7 @@ You are a consumer agent accessing the `[PRODUCT_NAME]` data product. Follow
 - **Question(s) to answer:** [what you want from the product]
 - **Connection:** [how you reach the platform / MCP endpoint]
 
-Check the trust gate before analytical use and tell me what it said. If discovery blocks you,
-or the gate flags the area I need, say so: don't fall back to guessing structure or
-presenting untrusted data as reliable.
+Read the trust map before analytical use, and tell me the confidence for the areas your answer
+actually rests on, with any gaps and what would close them. A weak or unvalidated area is not a
+reason to stop: answer, and say so plainly. If discovery blocks you, say that too - don't fall
+back to guessing structure or presenting a low-confidence result as a sound one.

--- a/prompts/Review_Data_Product_Starter.md
+++ b/prompts/Review_Data_Product_Starter.md
@@ -32,4 +32,6 @@ me. Be specific: cite the invariant or rule id behind every entry.
 - **Composition:** [which modules/patterns are in scope]
 
 Review one area at a time; let the map grow as you go. Tell me where an area has no automated
-check rather than recording it as passing.
+check rather than recording it as passing. Use the published map vocabulary from
+`design/patterns/validation.md` §4 - area scope, coverage, status, confidence, gaps, recommended
+action - so what you produce can be published into the product's own Observability store unchanged.

--- a/roles/access.md
+++ b/roles/access.md
@@ -34,41 +34,56 @@ Orient to the product, then navigate down:
 5. **Relationship.** Read the path-discovery surface for how to join what you need,
    including multi-hop paths.
 
-## Rule 2: the pre-use trust gate
+## Rule 2: the pre-use trust map
 
-**Read the gate before analytical use, not after.**
+**Read the map before analytical use, not after.** It does not gate you. It tells you how far
+to trust each part of the product, so you can answer with the confidence stated rather than
+implied - and so a defect somewhere you are not looking costs the user nothing.
 
 `design/patterns/validation.md` is authoritative on all of it:
 
 | What you need | Where |
 |---|---|
-| Status vocabulary and how `agent_use_allowed` derives from `trust_status` | §4 |
-| Severity model and what drives `UNTRUSTED` vs `DEGRADED` | §5 |
-| Consumption contract and **gate authority** - which producer's verdict is the gate | §9 |
+| The run record and the per-area entries a validator publishes | §3 |
+| The area key, coverage, and the status/confidence vocabularies | §4 |
+| Severity model: what makes an area `weak` rather than `partial` | §5 |
+| Consumption contract and **trust authority** - whose map you read | §9 |
 | Schema versioning (`payload_schema_version`, the `1.0` legacy binding) | §10 |
 | Staleness and incomplete evidence | §11 |
 
-The rules that matter most in practice:
+Four steps, in this order:
 
-- The product designates **one** gate-authoritative producer in its orientation metadata.
-  Read the latest result from *that* producer. Other producers' results are evidence -
-  surface disagreements, but they do not move the gate. Absent a designation, apply the
-  conservative composite: blocked if **any** producer's latest blocks.
-- `agent_use_allowed = stop` or `trust_status = UNTRUSTED` is a stop for autonomous use,
-  **with no silent override**. Tell the user what blocked it and what would unblock it.
-- `DEGRADED` permits use, but you must **surface the degradation** alongside the results.
-  Never present degraded output as sound.
-- **Stale evidence** (past `evidence_expires_dts`, or outside the product's window): stop for
-  autonomous use; surface prominently in an interactive session. Staleness only ever
-  downgrades.
-- **No evidence** is not the same as trusted. An unvalidated product is unvalidated; do not
-  proceed autonomously.
-- **Never re-derive the verdict yourself**, and never recount the capped JSON blobs. You are
-  read-only. Only a validator computes trust.
+1. **Read.** Find the map and the authoritative producer through orientation. The product
+   designates **one** trust-authoritative producer; that producer's entries are the map. Other
+   producers' entries are evidence - surface disagreements. Absent a designation, take the most
+   cautious entry per area and say that you did.
+2. **Select** the entries for the areas your query plan actually touches: the modules, entities,
+   patterns and capabilities behind the objects you resolved through `AccessObject`. Take the
+   narrowest entry that covers each. **Areas you do not touch place no constraint on your
+   answer** - do not withhold an answer because an unrelated module failed a check.
+3. **Proceed.** No confidence value withholds use. There is no verdict to wait for.
+4. **Disclose, proportionally.** State the confidence for each area you used:
+   - `strong` - say so; you have earned the right to.
+   - `partial` - name what is uncovered, from `open_gaps`.
+   - `weak`, or any CRITICAL/ERROR failure in an area you used - surface it prominently, say
+     what it means for *this* answer, and pass on `recommended_action`.
+   - `unknown` - report it as unknown. An area nothing checked is not an area that passed.
+
+And the standing rules:
+
+- **Stale evidence** (past `evidence_expires_dts`, or outside the product's window) reads at
+  `unknown` whatever it recorded. Say when it was validated and recommend a re-run. Staleness
+  only ever downgrades, and it does not stop you.
+- **No evidence** is not the same as trusted. An unvalidated area is unvalidated: report it that
+  way and answer anyway if the user's question can carry it.
+- **Never re-derive a status or a confidence yourself**, and never recount the capped JSON blobs.
+  You are read-only. Only a validator computes trust.
+- If your own operating policy sets a confidence floor for something you would do unsupervised,
+  that is yours to apply and to state. It is not something the product decided for you.
 
 ## Read on demand
 
-- **`design/patterns/validation.md`** - the gate, per the table above.
+- **`design/patterns/validation.md`** - the trust map, per the table above.
 - **`design/modules/semantic.md`** - what the orientation manifest, entity catalogue, column
   catalogue and path-discovery surfaces contain, and what each field means.
 - **`implementation/{platform}/modules/semantic/06-orientation.md`** - the concrete
@@ -88,8 +103,9 @@ identifier only, by design.
 ## Handover
 
 There is no handoff file: you read the deployed product directly. Your output is the answer,
-in this conversation, citing the entities and joins you used and any trust caveats for the
+in this conversation, citing the entities and joins you used and the trust map entries for the
 areas involved.
 
-If discovery blocks you, or the gate flags the area you need, say so. Do not fall back to
-guessing structure or presenting untrusted data as reliable.
+If discovery blocks you, say so. Where the map is weak or unknown for an area you used, give the
+answer *and* the caveat: do not fall back to guessing structure, and do not present a low-confidence
+result as a sound one.

--- a/roles/build.md
+++ b/roles/build.md
@@ -75,6 +75,15 @@ All paths below are under `implementation/{platform}/`.
 Where nothing ships, verify by hand against the design document's Invariants or Conformance
 section and tell the user that area has no automated check.
 
+**Deploy the trust map with the results table.** The validation pattern ships two relations:
+`validation_run` (the run summary) and `validation_area` (the per-area map a consumer reads), plus
+their views. Deploy them in file order into the Observability container. Each area you verify above
+is a map entry: an area whose check you ran, an area whose check does not exist
+(`checks_expected = 0`, which publishes as `no-evidence`), and an area you checked by hand. The map
+is what carries that distinction to every consumer that follows you, so record it as you go rather
+than reconstructing it at the end. Nothing you publish there blocks use of the product; an
+uncovered area is a coverage gap with a recommended action, not a failure.
+
 ## Handover
 
 Your input is the **design brief**; your output is the **deployable artefacts**, plus the

--- a/roles/review.md
+++ b/roles/review.md
@@ -5,6 +5,12 @@ validated, how strongly, and where the gaps are. The map is **knowledge for the 
 user**, not a barrier. Severe failures are surfaced prominently and their impact explained,
 but the decision to proceed stays with the user, informed by the map.
 
+The map is not a review artefact that stops with you. `design/patterns/validation.md` §3.2 and §4
+define the same map as a **published contract** - `scope_kind` / `scope_id`, coverage,
+`area_status`, `confidence`, `open_gaps`, `recommended_action` - which a validator writes into the
+product's Observability store for every consumer that follows you. Build yours in that vocabulary,
+so it can be published as-is rather than translated.
+
 Cite the invariant or rule id behind every entry.
 
 ## Read in this order
@@ -59,16 +65,22 @@ Cite the invariant or rule id behind every entry.
    weaker one. Then check the implementation honours what was recorded - a product that
    recorded `soft-delete` and bound a destructive delete is a failure checkable by the same
    machinery as the invariants.
-5. **Build the trust map.** Per module, entity and pattern record:
-   - **coverage** - which checks exist and which ran
-   - **status** - pass / fail / not-yet-validated / no-evidence
-   - **confidence** - strong / partial / weak / unknown
-   - **open gaps** - missing metadata, unregistered relationships, stale or missing
-     validation evidence, unvalidated areas, undocumented deviations
-6. **Recommend.** For each low-confidence or uncovered area, say what would raise trust:
-   more data, more analysis, more discovery, or a missing design decision.
+5. **Build the trust map.** One entry per area - a module, an entity, a pattern, a capability -
+   in the published vocabulary (`design/patterns/validation.md` §4):
+   - **coverage** - how many checks the area has (`checks_expected`) and how many ran
+     (`checks_ran`)
+   - **status** - `pass` / `fail` / `partial` / `not-validated` / `no-evidence`
+   - **confidence** - `strong` / `partial` / `weak` / `unknown`, by the §4.3 rules: nothing ran is
+     `unknown`; a CRITICAL/ERROR failure or coverage below half is `weak`; WARNING/INFO failures or
+     incomplete cover is `partial`; full coverage all passing is `strong`
+   - **open gaps** - missing metadata, unregistered relationships, stale or missing validation
+     evidence, unvalidated areas, undocumented deviations
+6. **Recommend.** Every entry below `strong` carries a recommended action: what would raise trust
+   here - a check to write, more data, more discovery, or a design decision to settle. This is the
+   half of the map a product owner acts on.
 7. **Report the map**: where the product is strong, where it is weak or unknown, and the
-   prioritised next steps.
+   prioritised next steps. An area at `weak` or `unknown` is not an area anyone is forbidden to
+   use; it is an area whose use comes with a stated caveat.
 
 Review one area at a time; the map grows as you go.
 
@@ -76,8 +88,9 @@ Review one area at a time; the map grows as you go.
 
 The severity vocabulary is normative and defined in `design/patterns/validation.md` §5:
 `INFO` | `WARNING` | `ERROR` | `CRITICAL`, on an axis independent of a check's status
-(`PASSED` / `FAILED` / `ERROR`). The gate consequences are defined there too: `CRITICAL` and
-`ERROR` failures drive `UNTRUSTED`; `WARNING` and `INFO` can only reach `DEGRADED`.
+(`PASSED` / `FAILED` / `ERROR`). Its consequences are defined there too, and they are now local to
+the area: `CRITICAL` and `ERROR` failures drive that area to `weak`; `WARNING` and `INFO` hold it
+at `partial`. Nothing withdraws the product.
 
 **Known gap** (tracked as issue #54). The corpus does not yet assign one of those severities
 to each individual `INV-*` and conformance rule, and there is no per-area index joining
@@ -97,6 +110,7 @@ checklist item and note the absence of an id.
 ## Handover
 
 Your inputs are the design brief and/or the built product; your output is the **trust map**.
-Once the product is deployed the map's durable home is **Observability**; before then it is a
-standalone report. Agree with the user where it goes based on what you can reach, and present
-it in the conversation either way.
+Once the product is deployed the map's durable home is **Observability**, as `validation_area`
+rows a validator publishes per run (`implementation/{platform}/patterns/validation/`); before then
+it is a standalone report. Agree with the user where it goes based on what you can reach, and
+present it in the conversation either way.

--- a/tooling/evals/reference/customer-orders.md
+++ b/tooling/evals/reference/customer-orders.md
@@ -229,8 +229,8 @@ registers on deploy through `SemanticRegistration`. The relationship graph carri
 Customer to Order, and Order to Product through OrderLine.
 
 The orientation relation lists the product's resources in `discovery_order` with the
-trust gate ordered before every analytical resource, so agents orient and check trust
-before touching data. The manifest is a generated view over the registry and that
+trust map ordered before every analytical resource, so agents orient and read how far each
+area can be trusted before touching data. The manifest is a generated view over the registry and that
 orientation relation, so it cannot drift from the metadata it summarises.
 
 Consumers resolve the object to query through the access-object registry rather than

--- a/tooling/validation/README.md
+++ b/tooling/validation/README.md
@@ -93,3 +93,11 @@ Module and pattern documents must never use either: they are exactly the content
 ```bash
 python -m unittest discover -s tooling/validation/tests
 ```
+
+Two kinds of test live there, and the distinction matters when one fails.
+
+**Corpus tests** hold the standards to their own rules: the linter's own behaviour, frontmatter and catalogue currency, and that every SQL template still renders canonical SQL under `StrictUndefined`. A failure means a document or a template is wrong.
+
+**Behavioural tests** execute shipped SQL. `test_trust_map.py` runs the validation pattern's read path — the trust map views, the consumer's scope reconciliation, and the conformance checks that resolve an area's identity — against stdlib `sqlite3`, through the narrow Teradata translator in `td_sqlite.py`. The SQL is read from `implementation/`, never retyped here, so reverting a fix in the pattern fails these tests. A failure means the *product's* SQL is wrong, not the standards.
+
+`td_sqlite.py` raises `UntranslatedSql` rather than guessing: a Teradata construct it does not handle breaks the harness loudly instead of being dropped from the statement it was load-bearing in. Extend it when the shipped SQL grows one. It is not a Teradata emulator and platform conformance is not its job — that stays the pattern's own `conformance-queries.sql`, run against a deployed product.

--- a/tooling/validation/tests/td_sqlite.py
+++ b/tooling/validation/tests/td_sqlite.py
@@ -1,0 +1,487 @@
+"""Run the validation pattern's shipped Teradata SQL against SQLite.
+
+The trust map's read path is logic, and the review of #57 found three defects in it that
+no amount of reading the file had caught: staleness graded against the wrong run, a
+legacy fallback that swallowed a malformed run, and a requested area that vanished
+instead of reporting itself unknown. Each is a behaviour, so each needs a test that
+states the behaviour and executes it.
+
+Nothing in `tooling/` may depend on a live Teradata, so the SQL is translated and run on
+stdlib `sqlite3`. That buys the tests teeth at the cost of one obvious risk: a translator
+can quietly mistranslate, and a test over a mistranslation is worse than no test. Two
+things hold that risk down.
+
+  * **The SQL is read from the shipped files**, never retyped here. Reverting a fix in
+    `04-trust-map-views.sql` fails these tests, which is the whole point.
+  * **The translator refuses to guess.** Every rewrite is explicit and narrow, and
+    `_assert_translated` raises `UntranslatedSql` if any Teradata construct survives it.
+    A new construct in the shipped SQL breaks the harness loudly rather than being
+    silently dropped from the statement it was load-bearing in.
+
+What this does *not* test is Teradata's own semantics: `QUALIFY` becomes a wrapped
+`ROW_NUMBER`, an `INTERVAL` becomes `datetime(...)`, and a zone-qualified timestamp
+becomes ISO text. Those are faithful for the comparisons the trust map makes and are not
+faithful in general. Conformance against the real platform stays the deployed
+`conformance-queries.sql`; this is the regression net underneath it.
+
+Timestamps are ISO `YYYY-MM-DD HH:MM:SS` UTC text, which SQLite's `CURRENT_TIMESTAMP`
+also produces, so the pattern's `<` comparisons sort correctly as strings.
+"""
+import re
+import sqlite3
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+VALIDATION = REPO_ROOT / "implementation" / "teradata" / "patterns" / "validation"
+SEMANTIC = REPO_ROOT / "implementation" / "teradata" / "modules" / "semantic"
+
+TS_FORMAT = "%Y-%m-%d %H:%M:%S"
+
+
+class UntranslatedSql(Exception):
+    """A construct the translator does not handle survived translation."""
+
+
+def now():
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+def ts(offset_days=0, offset_hours=0):
+    """An ISO timestamp offset from now, for building fresh and stale evidence."""
+    return (now() + timedelta(days=offset_days, hours=offset_hours)).strftime(TS_FORMAT)
+
+
+# --- lexing helpers ---------------------------------------------------------------
+# Every position-sensitive rewrite works over a copy with string literals blanked, so a
+# keyword or a parenthesis inside a comment string can never be mistaken for syntax.
+
+def _mask_strings(sql):
+    out = []
+    in_str = False
+    i = 0
+    while i < len(sql):
+        c = sql[i]
+        if in_str:
+            if c == "'":
+                if i + 1 < len(sql) and sql[i + 1] == "'":
+                    out.append("  ")
+                    i += 2
+                    continue
+                in_str = False
+            out.append(" ")
+        elif c == "'":
+            in_str = True
+            out.append(" ")
+        else:
+            out.append(c)
+        i += 1
+    return "".join(out)
+
+
+def _token_positions(sql, token):
+    masked = _mask_strings(sql)
+    return [m.start() for m in re.finditer(r"\b" + token + r"\b", masked)]
+
+
+def _depth_at(sql, pos):
+    masked = _mask_strings(sql)[:pos]
+    return masked.count("(") - masked.count(")")
+
+
+def _call_bounds(sql, name, start=0):
+    """(call_start, close_idx, inner_text) for the next balanced `name(...)` call."""
+    masked = _mask_strings(sql)
+    m = re.compile(r"\b" + name + r"\s*\(", re.I).search(masked, start)
+    if not m:
+        return None
+    open_idx = m.end() - 1
+    depth = 0
+    for i in range(open_idx, len(masked)):
+        if masked[i] == "(":
+            depth += 1
+        elif masked[i] == ")":
+            depth -= 1
+            if depth == 0:
+                return m.start(), i, sql[open_idx + 1:i]
+    raise UntranslatedSql("unbalanced parentheses after %s" % name)
+
+
+def _split_top_level(text, keyword):
+    """Split on `keyword` at paren depth 0. Returns the parts, keyword removed."""
+    parts = []
+    last = 0
+    for pos in _token_positions(text, keyword):
+        if _depth_at(text, pos) == 0:
+            parts.append(text[last:pos])
+            last = pos + len(keyword)
+    parts.append(text[last:])
+    return [p.strip() for p in parts]
+
+
+# --- statement splitting ---------------------------------------------------------
+
+def split_statements(text):
+    """Split a .sql file into statements, each keeping the comments that precede it.
+
+    The leading comments are the only stable handle on an individual query in
+    `conformance-queries.sql`, which is a flat sequence of checks identified by the
+    `-- VAL-nn` line above each one.
+    """
+    statements = []
+    buf = []
+    in_str = False
+    i = 0
+    while i < len(text):
+        c = text[i]
+        buf.append(c)
+        if in_str:
+            if c == "'":
+                if i + 1 < len(text) and text[i + 1] == "'":
+                    buf.append(text[i + 1])
+                    i += 2
+                    continue
+                in_str = False
+        elif c == "'":
+            in_str = True
+        elif c == "-" and i + 1 < len(text) and text[i + 1] == "-":
+            end = text.find("\n", i)
+            if end == -1:
+                end = len(text)
+            buf.append(text[i + 1:end])
+            i = end
+            continue
+        elif c == ";":
+            statements.append("".join(buf))
+            buf = []
+        i += 1
+    tail = "".join(buf)
+    if tail.strip():
+        statements.append(tail)
+    return [s for s in statements if s.strip()]
+
+
+def strip_comments(sql):
+    out = []
+    in_str = False
+    i = 0
+    while i < len(sql):
+        c = sql[i]
+        if in_str:
+            out.append(c)
+            if c == "'":
+                if i + 1 < len(sql) and sql[i + 1] == "'":
+                    out.append(sql[i + 1])
+                    i += 2
+                    continue
+                in_str = False
+            i += 1
+            continue
+        if c == "'":
+            in_str = True
+            out.append(c)
+            i += 1
+            continue
+        if c == "-" and i + 1 < len(sql) and sql[i + 1] == "-":
+            end = sql.find("\n", i)
+            if end == -1:
+                break
+            i = end
+            continue
+        out.append(c)
+        i += 1
+    return "".join(out)
+
+
+# --- rewrites --------------------------------------------------------------------
+
+def _rewrite_position(sql):
+    """POSITION('x' IN col) -> INSTR(col, 'x')"""
+    while True:
+        found = _call_bounds(sql, "POSITION")
+        if not found:
+            return sql
+        start, close, inner = found
+        parts = _split_top_level(inner, "IN")
+        if len(parts) != 2:
+            raise UntranslatedSql("unsupported POSITION argument: %r" % inner)
+        needle, haystack = parts
+        sql = sql[:start] + "INSTR(%s, %s)" % (haystack, needle) + sql[close + 1:]
+
+
+def _rewrite_substring(sql):
+    """SUBSTRING(col FROM a [FOR b]) -> SUBSTR(col, a[, b])"""
+    searched = 0
+    while True:
+        found = _call_bounds(sql, "SUBSTRING", searched)
+        if not found:
+            return sql
+        start, close, inner = found
+        parts = _split_top_level(inner, "FROM")
+        if len(parts) != 2:
+            raise UntranslatedSql("unsupported SUBSTRING argument: %r" % inner)
+        column, rest = parts
+        bounds = _split_top_level(rest, "FOR")
+        args = ", ".join([column] + bounds)
+        sql = sql[:start] + "SUBSTR(%s)" % args + sql[close + 1:]
+        searched = start
+
+
+def _rewrite_qualify(sql):
+    """QUALIFY <window expr> = n -> the window expression projected and filtered outside.
+
+    SQLite has no QUALIFY and forbids window functions in WHERE, so the enclosing SELECT
+    is wrapped: the window expression joins its select list under a private alias, and
+    the predicate becomes a WHERE on the wrapper. The wrapper projects `*`, so the
+    result carries one extra column; nothing in the shipped SQL reads these relations
+    with `SELECT *`, so the views' column contracts are unaffected.
+    """
+    while True:
+        positions = _token_positions(sql, "QUALIFY")
+        if not positions:
+            return sql
+        idx = positions[0]
+        depth = _depth_at(sql, idx)
+
+        select_start = None
+        for pos in _token_positions(sql, "SELECT"):
+            if pos < idx and _depth_at(sql, pos) == depth:
+                select_start = pos
+        if select_start is None:
+            raise UntranslatedSql("QUALIFY with no enclosing SELECT at the same depth")
+
+        masked = _mask_strings(sql)
+        end = len(sql)
+        running = depth
+        for i in range(idx, len(sql)):
+            if masked[i] == "(":
+                running += 1
+            elif masked[i] == ")":
+                running -= 1
+                if running < depth:
+                    end = i
+                    break
+            elif masked[i] == ";" and running == depth:
+                end = i
+                break
+
+        inner = sql[select_start:idx]
+        predicate = sql[idx + len("QUALIFY"):end]
+        m = re.match(r"^\s*(?P<expr>.+?)\s*=\s*(?P<value>\d+)\s*$", predicate, re.S)
+        if not m:
+            raise UntranslatedSql("unsupported QUALIFY predicate: %r" % predicate)
+
+        from_pos = None
+        for pos in _token_positions(inner, "FROM"):
+            if _depth_at(inner, pos) == 0:
+                from_pos = pos
+                break
+        if from_pos is None:
+            raise UntranslatedSql("QUALIFY block has no top-level FROM")
+
+        ranked = (inner[:from_pos].rstrip()
+                  + "\n    , " + m.group("expr") + " AS _row_pick\n"
+                  + inner[from_pos:])
+        sql = (sql[:select_start]
+               + "SELECT * FROM (\n" + ranked
+               + "\n) AS _ranked WHERE _row_pick = " + m.group("value") + "\n"
+               + sql[end:])
+
+
+# Constructs that must not survive translation. Each is either rewritten above or the
+# statement carrying it is dropped; anything left means the harness has gone stale
+# against the shipped SQL and must be extended rather than trusted.
+_UNTRANSLATED = (
+    "QUALIFY", "LOCKING", "MULTISET", "PRIMARY INDEX", "COLLECT STATISTICS",
+    "CHARACTER SET", "INTERVAL", "BYTEINT", "SMALLINT", "POSITION(", "SUBSTRING(",
+    "DECIMAL(", "WITH TIME ZONE", "GENERATED ALWAYS", "REPLACE VIEW", "{db}", "{sem}",
+)
+
+
+def _assert_translated(sql):
+    masked = _mask_strings(sql).upper()
+    for token in _UNTRANSLATED:
+        # Keyword tokens match on word boundaries: a rewrite is free to introduce an
+        # alias containing one, and a substring test would flag its own output.
+        if re.fullmatch(r"[\w ]+", token):
+            hit = re.search(r"\b" + token.replace(" ", r"\s+") + r"\b", masked)
+        else:
+            hit = token.upper() in masked
+        if hit:
+            raise UntranslatedSql(
+                "%r survived translation - extend td_sqlite for the construct the "
+                "shipped SQL now uses:\n%s" % (token, sql.strip()[:400]))
+
+
+def translate(sql):
+    """Translate one Teradata statement, or None where it has no SQLite equivalent."""
+    s = strip_comments(sql)
+    if not s.strip():
+        return None
+    if re.match(r"^\s*(COLLECT STATISTICS|COMMENT ON)\b", s, re.I):
+        return None
+
+    s = s.replace("{db}.", "").replace("{sem}.", "")
+    s = re.sub(r"\bLOCKING ROW FOR ACCESS\b", "", s, flags=re.I)
+    s = re.sub(r"\bREPLACE VIEW\b", "CREATE VIEW", s, flags=re.I)
+    s = re.sub(r"\bCREATE MULTISET TABLE\b", "CREATE TABLE", s, flags=re.I)
+    s = re.sub(r"\s+CHARACTER SET (LATIN|UNICODE)\b", "", s, flags=re.I)
+    s = re.sub(r"\bTIMESTAMP\(\d+\)\s+WITH TIME ZONE\b", "TEXT", s, flags=re.I)
+    s = re.sub(r"\bJSON\(\d+\)", "TEXT", s, flags=re.I)
+    s = re.sub(r"\b(BYTEINT|SMALLINT)\b", "INTEGER", s, flags=re.I)
+    s = re.sub(r"\s+GENERATED ALWAYS AS IDENTITY\b", "", s, flags=re.I)
+    s = re.sub(r"\bCURRENT_TIMESTAMP\(\d+\)", "CURRENT_TIMESTAMP", s, flags=re.I)
+    s = re.sub(r"\bDECIMAL\(\s*\d+\s*,\s*\d+\s*\)", "REAL", s, flags=re.I)
+    s = re.sub(r"([\w.]+)\s*\+\s*INTERVAL\s*'(\d+)'\s*DAY\b",
+               r"datetime(\1, '+\2 days')", s, flags=re.I)
+    s = _rewrite_position(s)
+    s = _rewrite_substring(s)
+    s = re.sub(r"\)\s*PRIMARY INDEX\s*\([^)]*\)\s*;", ");", s, flags=re.I)
+    s = _rewrite_qualify(s)
+
+    _assert_translated(s)
+    return s
+
+
+# --- the fixture -----------------------------------------------------------------
+
+# Stand-ins for the Semantic catalogue relations VAL-14 resolves an area against, and for
+# the caller-populated request relation. The shipped DDL for the catalogue tables is a
+# Jinja template importing the temporal macros, and loading it would drag the whole
+# temporal block into a fixture that needs two columns from each. The names are asserted
+# against the shipped templates by test_trust_map.SemanticStandInsMatchShippedDdl, so
+# this cannot drift silently.
+_STAND_INS = (
+    "CREATE TABLE entity_metadata (module_name TEXT, entity_name TEXT, is_active INTEGER)",
+    "CREATE TABLE data_product_map (module_name TEXT, is_active INTEGER)",
+    "CREATE TABLE data_product_orientation ("
+    " product_id TEXT, resource_role TEXT, discovery_order INTEGER, is_active INTEGER)",
+    # Populated by the consumer per request, not deployed by the product, so it has no
+    # shipped DDL of its own (consumer-queries.sql query 1).
+    "CREATE TABLE requested_validation_scope (scope_kind TEXT, scope_id TEXT)",
+)
+
+RUN_DEFAULTS = dict(
+    product_prefix="CALLCENTRE", producer_id="trust-engine", producer_version="1.0",
+    profile_id=None, profile_version=None, source_format="NATIVE",
+    payload_schema_version="2.1", run_id="R1",
+    started_dts=None, completed_dts=None,
+    trust_status="TRUSTED", agent_use_allowed=1,
+    total_checks=10, passed_count=10, failed_count=0, error_count=0,
+    critical_failure_count=0, error_failure_count=0,
+    data_product_trust_score=100, performance_readiness_score=None,
+    operational_readiness_score=None, repair_candidate_count=0,
+    failed_checks_json=None, repair_candidates_json=None, evidence_expires_dts=None,
+)
+
+AREA_DEFAULTS = dict(
+    product_prefix="CALLCENTRE", producer_id="trust-engine", run_id="R1",
+    scope_kind="MODULE", scope_id="domain",
+    checks_expected=4, checks_ran=4,
+    passed_count=4, failed_count=0, error_count=0,
+    critical_failure_count=0, error_failure_count=0,
+    area_status="pass", confidence="strong",
+    open_gaps=None, recommended_action=None, completed_dts=None,
+)
+
+
+class Fixture:
+    """An in-memory deployment of the validation pattern's shipped relations."""
+
+    FILES = ("01-validation-run.sql", "03-validation-area.sql",
+             "02-views.sql", "04-trust-map-views.sql")
+
+    def __init__(self):
+        self.db = sqlite3.connect(":memory:")
+        self.db.row_factory = sqlite3.Row
+        for statement in _STAND_INS:
+            self.db.execute(statement)
+        for name in self.FILES:
+            self.load(VALIDATION / name)
+
+    def close(self):
+        self.db.close()
+
+    def load(self, path):
+        for raw in split_statements(path.read_text(encoding="utf-8")):
+            translated = translate(raw)
+            if translated is None:
+                continue
+            try:
+                self.db.execute(translated)
+            except sqlite3.Error as exc:
+                raise AssertionError(
+                    "%s: %s\n%s" % (path.name, exc, translated.strip()[:600])) from exc
+
+    # -- population ---------------------------------------------------------------
+
+    def insert_run(self, **overrides):
+        row = dict(RUN_DEFAULTS)
+        row.update(overrides)
+        if row["completed_dts"] is None:
+            row["completed_dts"] = ts()
+        if row["started_dts"] is None:
+            row["started_dts"] = row["completed_dts"]
+        self._insert("validation_run", row)
+        return row
+
+    def insert_area(self, **overrides):
+        row = dict(AREA_DEFAULTS)
+        row.update(overrides)
+        if row["completed_dts"] is None:
+            # The area inherits its run's completion instant (VAL-09); defaulting to the
+            # parent run's value rather than to now() keeps a fixture honest by default.
+            parent = self.db.execute(
+                "SELECT completed_dts FROM validation_run"
+                " WHERE product_prefix = ? AND producer_id = ? AND run_id = ?",
+                (row["product_prefix"], row["producer_id"], row["run_id"])).fetchone()
+            row["completed_dts"] = parent["completed_dts"] if parent else ts()
+        if row["confidence"] != "strong":
+            row["open_gaps"] = row["open_gaps"] or "Fixture gap."
+            row["recommended_action"] = row["recommended_action"] or "Fixture action."
+        self._insert("validation_area", row)
+        return row
+
+    def request(self, *scopes):
+        self.db.executemany(
+            "INSERT INTO requested_validation_scope (scope_kind, scope_id) VALUES (?, ?)",
+            scopes)
+
+    def _insert(self, table, row):
+        columns = ", ".join(row)
+        markers = ", ".join("?" for _ in row)
+        self.db.execute("INSERT INTO %s (%s) VALUES (%s)" % (table, columns, markers),
+                        tuple(row.values()))
+
+    # -- reading ------------------------------------------------------------------
+
+    def rows(self, sql, params=None):
+        return [dict(r) for r in self.db.execute(sql, params or {}).fetchall()]
+
+    def trust_map(self, **filters):
+        where = " AND ".join("%s = :%s" % (k, k) for k in filters) or "1 = 1"
+        return self.rows("SELECT * FROM validation_trust_map WHERE " + where, filters)
+
+
+def statement_from(path, marker, substitutions=None):
+    """The translated statement whose leading comments contain `marker`.
+
+    `substitutions` is applied to the file text first, for the one template in scope
+    here (`modules/semantic/validation.sql.j2`) whose only Jinja is `{{ product }}`
+    interpolation. A plain replace is exact for that; it is not a Jinja renderer, and a
+    template that grows a `{% %}` block needs the real thing instead.
+    """
+    text = path.read_text(encoding="utf-8")
+    for old, new in (substitutions or {}).items():
+        text = text.replace(old, new)
+    matches = [s for s in split_statements(text) if marker in s]
+    if not matches:
+        raise AssertionError(
+            "no statement in %s carries the marker %r - the check was renamed or "
+            "removed, and the test that depends on it is now vacuous"
+            % (path.name, marker))
+    if len(matches) > 1:
+        raise AssertionError(
+            "the marker %r matches %d statements in %s; make it unambiguous"
+            % (marker, len(matches), path.name))
+    return translate(matches[0])

--- a/tooling/validation/tests/test_trust_map.py
+++ b/tooling/validation/tests/test_trust_map.py
@@ -1,0 +1,406 @@
+"""The trust map's read path, executed.
+
+Every scenario here is one the review of #57 asked for. They are behavioural, not
+structural: each states a property of the map a consumer depends on, then executes the
+shipped SQL to check it holds. That matters because all three read-path defects the
+review found were invisible to inspection and obvious the moment the query ran.
+
+The properties, and why each is worth a test rather than a comment:
+
+  * **Areas are graded against the run that produced them.** The map resolves the latest
+    entry per area independently, so two entries can come from different runs. Grading
+    staleness against the producer's newest run therefore certifies old evidence as
+    fresh - a passed check being reported for a state of the product that no longer
+    holds, which is the one thing staleness exists to prevent.
+  * **The legacy fallback covers legacy producers only.** It exists so a 2.0 producer
+    still has a readable one-area map. A malformed 2.1 run that publishes no areas must
+    fail VAL-18 instead of being re-dressed as legacy, and a future major version must
+    not be mistaken for an old one by a string comparison.
+  * **A requested area always answers.** An area with no published entry reads
+    `no-evidence` / `unknown`. Dropping the row instead makes an unvalidated area
+    indistinguishable from a sound one: the exact failure the map was built to remove.
+  * **An area's identity resolves.** `scope_id` typos are silent - a check reporting on
+    `MODULE:domian` passes every count-based rule and describes nothing.
+
+Run:
+    python -m unittest discover -s tooling/validation/tests
+"""
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from td_sqlite import (  # noqa: E402
+    SEMANTIC,
+    VALIDATION,
+    Fixture,
+    statement_from,
+    ts,
+)
+
+CONFORMANCE = VALIDATION / "conformance-queries.sql"
+CONSUMER = VALIDATION / "consumer-queries.sql"
+SEMANTIC_CHECKS = SEMANTIC / "validation.sql.j2"
+
+PRODUCT = "CALLCENTRE"
+PRODUCER = "trust-engine"
+PARAMS = {"product_prefix": PRODUCT, "trust_producer": PRODUCER}
+
+
+class TrustMapCase(unittest.TestCase):
+    def setUp(self):
+        self.fx = Fixture()
+        self.addCleanup(self.fx.close)
+
+    def entry(self, scope_kind, scope_id):
+        rows = self.fx.trust_map(scope_kind=scope_kind, scope_id=scope_id)
+        self.assertEqual(
+            len(rows), 1,
+            "expected exactly one map entry for %s:%s, got %d - the latest-per-area "
+            "projection is not deterministic" % (scope_kind, scope_id, len(rows)))
+        return rows[0]
+
+    def conformance(self, marker, params=None):
+        """Rows returned by a conformance check. Zero rows means conforming."""
+        return self.fx.rows(statement_from(CONFORMANCE, marker), params)
+
+
+class StalenessIsPerArea(TrustMapCase):
+    """Scenario 1-3: mixed-age areas."""
+
+    def test_each_area_is_graded_against_its_own_run(self):
+        # Two areas whose latest entries come from runs 29 days apart. Both were 'strong'
+        # when recorded; only the older one is past the 7-day default window now.
+        self.fx.insert_run(run_id="OLD", completed_dts=ts(-29))
+        self.fx.insert_area(run_id="OLD", scope_kind="MODULE", scope_id="search")
+        self.fx.insert_run(run_id="NEW", completed_dts=ts(-1))
+        self.fx.insert_area(run_id="NEW", scope_kind="MODULE", scope_id="domain")
+
+        stale = self.entry("MODULE", "search")
+        fresh = self.entry("MODULE", "domain")
+
+        self.assertEqual(stale["evidence_is_stale"], 1)
+        self.assertEqual(
+            stale["confidence"], "unknown",
+            "a 29-day-old area read at its recorded confidence: staleness is being "
+            "evaluated against a newer run than the one that produced this evidence")
+        self.assertEqual(
+            stale["recorded_confidence"], "strong",
+            "the recorded confidence must survive alongside the downgrade, so a "
+            "consumer can say what the evidence claimed and when")
+
+        self.assertEqual(fresh["evidence_is_stale"], 0)
+        self.assertEqual(fresh["confidence"], "strong")
+
+    def test_a_newer_run_does_not_refresh_an_area_it_did_not_cover(self):
+        # The producer's latest run is minutes old but covers only 'domain'. The 'search'
+        # entry it left untouched is still 40-day-old evidence and must read that way.
+        self.fx.insert_run(run_id="OLD", completed_dts=ts(-40))
+        self.fx.insert_area(run_id="OLD", scope_kind="MODULE", scope_id="search")
+        self.fx.insert_run(run_id="LATEST", completed_dts=ts())
+        self.fx.insert_area(run_id="LATEST", scope_kind="MODULE", scope_id="domain")
+
+        self.assertEqual(
+            self.entry("MODULE", "search")["confidence"], "unknown",
+            "an area untouched by the newest run was graded by that run's clock")
+
+    def test_a_producer_declared_expiry_overrides_the_default_window(self):
+        # Inside the 7-day window, but the producer said this evidence expires sooner.
+        self.fx.insert_run(run_id="R1", completed_dts=ts(-2),
+                           evidence_expires_dts=ts(-1))
+        self.fx.insert_area(run_id="R1", scope_kind="MODULE", scope_id="domain")
+
+        entry = self.entry("MODULE", "domain")
+        self.assertEqual(entry["evidence_is_stale"], 1)
+        self.assertEqual(entry["confidence"], "unknown")
+        self.assertIn("re-run", entry["recommended_action"].lower())
+
+    def test_the_latest_entry_per_area_breaks_ties_deterministically(self):
+        # Two runs completing in the same instant: VAL-09 makes run_id DESC the tie-break,
+        # so the projection yields one row rather than an arbitrary one or both.
+        same_instant = ts(-1)
+        for run_id in ("RUN-A", "RUN-B"):
+            self.fx.insert_run(run_id=run_id, completed_dts=same_instant)
+        self.fx.insert_area(run_id="RUN-A", area_status="pass", confidence="strong")
+        self.fx.insert_area(run_id="RUN-B", area_status="fail", confidence="weak",
+                            passed_count=3, failed_count=1, critical_failure_count=1)
+
+        self.assertEqual(self.entry("MODULE", "domain")["run_id"], "RUN-B")
+
+
+class LegacyFallbackIsScoped(TrustMapCase):
+    """Scenario 4-6: legacy runs, and the runs that must not be treated as legacy."""
+
+    def test_a_legacy_run_projects_one_derived_product_entry(self):
+        self.fx.insert_run(run_id="L1", payload_schema_version="2.0",
+                           completed_dts=ts(-1), total_checks=8, passed_count=8)
+
+        entry = self.entry("PRODUCT", PRODUCT)
+        self.assertEqual(entry["map_source"], "DERIVED")
+        self.assertEqual(
+            entry["confidence"], "partial",
+            "a derived entry is capped at 'partial': a run-level pass says nothing "
+            "about which areas the run covered")
+        self.assertEqual(entry["area_status"], "pass")
+        self.assertTrue(entry["open_gaps"], "a derived entry must state its own limits")
+
+    def test_a_malformed_canonical_run_is_not_re_dressed_as_legacy(self):
+        # A 2.1 run that published no area rows. It has no map, and that is a defect to
+        # report - not a legacy producer to accommodate.
+        self.fx.insert_run(run_id="BAD", payload_schema_version="2.1",
+                           completed_dts=ts(-1))
+
+        self.assertEqual(
+            self.fx.trust_map(), [],
+            "a 2.1 run publishing no areas was given a derived PRODUCT entry, which "
+            "hides the defect behind a map that looks legitimate")
+        self.assertEqual(
+            len(self.conformance(
+                "VAL-18 (every canonical-schema run publishes at least one area entry")),
+            1,
+            "the malformed run must be reported by VAL-18 instead")
+
+    def test_the_fallback_is_scoped_to_the_run_not_the_producer(self):
+        # The producer published 2.1 areas historically and has now regressed to a 2.0
+        # run. The current run still needs a readable map, so the fallback must fire for
+        # it despite the older run's area rows existing.
+        self.fx.insert_run(run_id="HIST", payload_schema_version="2.1",
+                           completed_dts=ts(-3))
+        self.fx.insert_area(run_id="HIST", scope_kind="MODULE", scope_id="domain")
+        self.fx.insert_run(run_id="NOW", payload_schema_version="2.0",
+                           completed_dts=ts(-1), total_checks=6, passed_count=6)
+
+        derived = [r for r in self.fx.trust_map() if r["map_source"] == "DERIVED"]
+        self.assertEqual(
+            len(derived), 1,
+            "the legacy fallback was suppressed by an unrelated older run's area rows, "
+            "leaving the current run with no map at all")
+        self.assertEqual(derived[0]["run_id"], "NOW")
+
+    def test_an_unregistered_future_version_is_not_treated_as_legacy(self):
+        # '10.0' sorts below '2.1' as a string. A lexical test would call this legacy and
+        # publish a derived entry over a schema it has never seen.
+        self.fx.insert_run(run_id="FUTURE", payload_schema_version="10.0",
+                           completed_dts=ts(-1))
+
+        self.assertEqual(
+            [r for r in self.fx.trust_map() if r["map_source"] == "DERIVED"], [],
+            "a future major version was matched as a legacy binding by string "
+            "comparison; legacy versions are enumerated explicitly")
+
+    def test_a_future_version_is_still_held_to_the_canonical_rules(self):
+        # The other half of the same rule: excluding registered legacy versions means a
+        # future version stays inside every canonical check rather than falling out of it.
+        self.fx.insert_run(run_id="FUTURE", payload_schema_version="10.0",
+                           completed_dts=ts(-1), agent_use_allowed=0)
+
+        self.assertEqual(
+            len(self.conformance("VAL-02")), 1,
+            "a 10.0 run escaped VAL-02: the check is selecting records by comparing "
+            "payload_schema_version lexically against '2.1'")
+
+
+class RequestedAreasAlwaysAnswer(TrustMapCase):
+    """Scenario 7: a requested area with no published entry."""
+
+    def reconciled(self):
+        return self.fx.rows(
+            statement_from(CONSUMER, "-- 1. The areas this query plan touches"), PARAMS)
+
+    def test_an_area_with_no_entry_reads_unknown_rather_than_disappearing(self):
+        self.fx.insert_run(run_id="R1", completed_dts=ts(-1))
+        self.fx.insert_area(run_id="R1", scope_kind="MODULE", scope_id="domain")
+        self.fx.request(("MODULE", "domain"), ("ENTITY", "domain.Ticket"))
+
+        rows = {(r["scope_kind"], r["scope_id"]): r for r in self.reconciled()}
+
+        self.assertEqual(
+            len(rows), 2,
+            "a requested area vanished from the result: an area the map says nothing "
+            "about is indistinguishable from one it passed")
+        missing = rows[("ENTITY", "domain.Ticket")]
+        self.assertEqual(missing["area_status"], "no-evidence")
+        self.assertEqual(missing["confidence"], "unknown")
+        self.assertEqual(missing["map_source"], "NONE")
+        self.assertTrue(missing["open_gaps"])
+        self.assertTrue(missing["recommended_action"])
+        self.assertEqual(rows[("MODULE", "domain")]["confidence"], "strong")
+
+    def test_areas_the_request_does_not_touch_are_absent(self):
+        # The complement of the rule above: the map does not volunteer unrelated areas,
+        # because a failure outside what the query reaches places no constraint on it.
+        self.fx.insert_run(run_id="R1", completed_dts=ts(-1))
+        self.fx.insert_area(run_id="R1", scope_kind="MODULE", scope_id="domain")
+        self.fx.insert_area(run_id="R1", scope_kind="MODULE", scope_id="prediction",
+                            area_status="fail", confidence="weak",
+                            passed_count=3, failed_count=1, critical_failure_count=1)
+        self.fx.request(("MODULE", "domain"))
+
+        self.assertEqual([r["scope_id"] for r in self.reconciled()], ["domain"])
+
+    def test_a_requested_area_whose_evidence_is_stale_reads_unknown(self):
+        self.fx.insert_run(run_id="R1", completed_dts=ts(-30))
+        self.fx.insert_area(run_id="R1", scope_kind="MODULE", scope_id="domain")
+        self.fx.request(("MODULE", "domain"))
+
+        row = self.reconciled()[0]
+        self.assertEqual(row["confidence"], "unknown")
+        self.assertEqual(row["evidence_is_stale"], 1)
+        self.assertEqual(row["recorded_confidence"], "strong")
+
+
+class AreaIdentityResolves(TrustMapCase):
+    """Scenario 8: invalid identifiers."""
+
+    def setUp(self):
+        super().setUp()
+        self.fx.db.execute(
+            "INSERT INTO data_product_map (module_name, is_active) VALUES ('DOMAIN', 1)")
+        self.fx.db.execute(
+            "INSERT INTO entity_metadata (module_name, entity_name, is_active)"
+            " VALUES ('DOMAIN', 'Ticket', 1)")
+        self.fx.insert_run(run_id="R1", completed_dts=ts(-1))
+
+    def test_a_module_typo_is_reported(self):
+        self.fx.insert_area(run_id="R1", scope_kind="MODULE", scope_id="domian")
+
+        found = self.conformance("VAL-14 (MODULE scope resolves)")
+        self.assertEqual(
+            [r["scope_id"] for r in found], ["domian"],
+            "a module-scoped area naming no deployed module passed VAL-14; the check "
+            "accepts any non-empty string")
+
+    def test_a_real_module_resolves(self):
+        self.fx.insert_area(run_id="R1", scope_kind="MODULE", scope_id="domain")
+        self.assertEqual(self.conformance("VAL-14 (MODULE scope resolves)"), [])
+
+    def test_an_inactive_module_does_not_resolve(self):
+        self.fx.db.execute("INSERT INTO data_product_map (module_name, is_active)"
+                           " VALUES ('SEARCH', 0)")
+        self.fx.insert_area(run_id="R1", scope_kind="MODULE", scope_id="search")
+
+        self.assertEqual(
+            [r["scope_id"] for r in self.conformance("VAL-14 (MODULE scope resolves)")],
+            ["search"],
+            "an area scoped to a module the product has retired resolved anyway")
+
+    def test_a_product_scope_naming_another_product_is_reported(self):
+        self.fx.insert_area(run_id="R1", scope_kind="PRODUCT", scope_id="OTHERPRODUCT",
+                            checks_expected=1, checks_ran=1, passed_count=1)
+
+        self.assertEqual(
+            [r["scope_id"] for r in self.conformance("VAL-14 (PRODUCT scope resolves)")],
+            ["OTHERPRODUCT"])
+
+    def test_an_entity_scope_must_be_module_qualified_and_catalogued(self):
+        self.fx.insert_area(run_id="R1", scope_kind="ENTITY", scope_id="domain.Ticket")
+        self.fx.insert_area(run_id="R1", scope_kind="ENTITY", scope_id="domain.Phantom")
+
+        self.assertEqual(
+            [r["scope_id"] for r in self.conformance("VAL-14 (ENTITY scope resolves)")],
+            ["domain.Phantom"],
+            "an entity-scoped area naming no catalogued entity resolved anyway")
+
+    def test_an_areas_completed_dts_must_match_its_run(self):
+        # VAL-09. The trust map joins an area to its own run to date the evidence, so an
+        # area carrying a different instant dates itself against a clock it never ran on.
+        self.fx.insert_area(run_id="R1", scope_kind="MODULE", scope_id="domain",
+                            completed_dts=ts(-9))
+
+        self.assertEqual(
+            len(self.conformance("VAL-09: an area's completed_dts")), 1,
+            "an area whose completed_dts disagrees with its parent run passed VAL-09")
+
+
+class TrustRoleIsCanonicalised(unittest.TestCase):
+    """Scenario 9: TRUST_GATE and TRUST_MAP are one role under two spellings.
+
+    The manifest treats them as aliases, so the singular-role check has to as well.
+    Grouping the raw strings lets a product publish both and pass, which is how a
+    product ends up with two trust entrypoints and a reader that picks one by string
+    ordering.
+    """
+
+    ROLE_CHECK = "INV-SEMANTIC-011: duplicate active role for one product"
+
+    def setUp(self):
+        self.fx = Fixture()
+        self.addCleanup(self.fx.close)
+        self.query = statement_from(
+            SEMANTIC_CHECKS, self.ROLE_CHECK,
+            substitutions={"{{ product }}_Semantic.": ""})
+
+    def add_role(self, role, order, product="CALLCENTRE"):
+        self.fx.db.execute(
+            "INSERT INTO data_product_orientation"
+            " (product_id, resource_role, discovery_order, is_active)"
+            " VALUES (?, ?, ?, 1)", (product, role, order))
+
+    def test_both_spellings_of_the_trust_role_count_as_a_duplicate(self):
+        self.add_role("MANIFEST", 1)
+        self.add_role("TRUST_MAP", 2)
+        self.add_role("TRUST_GATE", 3)
+
+        found = self.fx.rows(self.query)
+        self.assertEqual(
+            [r["canonical_resource_role"] for r in found], ["TRUST_MAP"],
+            "a product publishing both spellings of the trust role passed the "
+            "singular-role check")
+
+    def test_one_spelling_is_not_a_duplicate(self):
+        self.add_role("MANIFEST", 1)
+        self.add_role("TRUST_GATE", 2)
+        self.assertEqual(self.fx.rows(self.query), [])
+
+    def test_an_ordinary_duplicate_role_is_still_reported(self):
+        self.add_role("ENTITY_CATALOGUE", 1)
+        self.add_role("ENTITY_CATALOGUE", 2)
+
+        self.assertEqual(
+            [r["canonical_resource_role"] for r in self.fx.rows(self.query)],
+            ["ENTITY_CATALOGUE"])
+
+    def test_a_retired_row_does_not_make_a_duplicate(self):
+        self.add_role("TRUST_MAP", 2)
+        self.fx.db.execute(
+            "INSERT INTO data_product_orientation"
+            " (product_id, resource_role, discovery_order, is_active)"
+            " VALUES ('CALLCENTRE', 'TRUST_GATE', 3, 0)")
+
+        self.assertEqual(self.fx.rows(self.query), [])
+
+
+class SemanticStandInsMatchShippedDdl(unittest.TestCase):
+    """The fixture's stand-in tables must name columns the shipped DDL still has.
+
+    VAL-14 resolves an area against the Semantic catalogue, so these tests are only
+    meaningful while the columns they join on exist. A rename in the Semantic module
+    would otherwise leave the checks passing against a schema the product does not have.
+    """
+
+    REQUIRED = {
+        "01-catalog-tables.sql.j2": ("entity_metadata", ("module_name", "entity_name")),
+        "02-discovery-tables.sql.j2": ("data_product_map", ("module_name", "is_active")),
+        "09-orientation-manifest.sql.j2": ("data_product_orientation",
+                                           ("product_id", "resource_role", "is_active")),
+    }
+
+    def test_every_stand_in_column_exists_in_the_shipped_template(self):
+        for template, (table, columns) in self.REQUIRED.items():
+            text = (SEMANTIC / template).read_text(encoding="utf-8")
+            with self.subTest(table=table):
+                self.assertIn(
+                    table, text,
+                    "%s no longer declares %s: the VAL-14 tests join to a stand-in for "
+                    "a relation that has moved or been renamed" % (template, table))
+                for column in columns:
+                    self.assertIn(
+                        column, text,
+                        "%s.%s is gone from %s; update the stand-in in td_sqlite and the "
+                        "conformance query that joins on it"
+                        % (table, column, template))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Closes #46.

## The change

A validation run published one verdict for the whole product: any CRITICAL/ERROR failure anywhere set `agent_use_allowed = stop` and withdrew autonomous use of everything. A defect in Prediction cost an agent the Domain question it was actually asked.

A run now also publishes **one entry per area** — module, entity, pattern, capability — carrying coverage, status, confidence, open gaps and a recommended action. A consumer reads the entries for the areas its query plan touches, proceeds, and discloses their confidence alongside the answer. Nothing in the contract withholds use: what a failure costs is bounded by the area it belongs to, and `strong` becomes a positive statement of confidence rather than the absence of a block.

## Wire schema 2.1 (additive over 2.0)

- New `ValidationArea` entity (`validation_area`) and the `validation_trust_map` view. A 2.0 producer projects one derived `PRODUCT` entry, capped at `partial`, so the map has one shape everywhere.
- `agent_use_allowed` deprecated in place: retained so a 2.0 reader still parses a 2.1 record, published as go, never branched on.
- `trust_status` kept as an advisory summary of the map.
- Checks declare a scope,