### PR TITLE
fix(validation): address PR #57 review feedback on the per-area trust map

### DIFF
--- a/design/patterns/validation.md
+++ b/design/patterns/validation.md
@@ -347,7 +347,7 @@ The result is mappable from/to established open formats; `source_format` records
 | VAL-11 | Producer and consumer build gates verify the shared golden fixture at the declared schema version. |
 | VAL-12 | Every record carries non-null `producer_id` and `payload_schema_version`. |
 | VAL-13 | The map is taken from the designated producer; absent designation, the most cautious entry per area applies and the consumer says so. |
-| VAL-14 | `scope_kind`, `area_status`, and `confidence` come from their vocabularies, and `scope_id` resolves to a real module, entity, pattern, capability, or the product. |
+| VAL-14 | `scope_kind`, `area_status`, and `confidence` come from their vocabularies, and `scope_id` resolves to a real module, entity, pattern, capability, or the product. Runtime-checkable for `PRODUCT`, `MODULE`, and `ENTITY` against deployed catalogue metadata; `PATTERN` and `CAPABILITY` have no deployed catalogue to resolve against, so the producer's build-time assertion against its own validator profile is the enforcement point. |
 | VAL-15 | Per area: `checks_ran = passed_count + failed_count + error_count`, and `checks_ran` never exceeds `checks_expected`. |
 | VAL-16 | `pass` and `strong` require checks that ran at full coverage; `no-evidence` and `not-validated` carry `confidence` = `unknown`. |
 | VAL-17 | Every entry below `strong` carries `open_gaps` and `recommended_action`. |

--- a/implementation/teradata/modules/semantic/09-orientation-manifest.sql.j2
+++ b/implementation/teradata/modules/semantic/09-orientation-manifest.sql.j2
@@ -55,9 +55,14 @@ SELECT
       r.product_id, r.product_name, r.product_version, r.product_status, r.owner_team
     , r.approved_access_mode, r.approved_entrypoint
     , MAX(CASE WHEN o.resource_role = 'MANIFEST'               THEN o.fully_qualified_object_name END)
-      -- TRUST_GATE is the legacy spelling of TRUST_MAP; readers honour both.
-    , MAX(CASE WHEN o.resource_role IN ('TRUST_MAP', 'TRUST_GATE')
-                                                               THEN o.fully_qualified_object_name END)
+      -- TRUST_GATE is the legacy spelling of TRUST_MAP; readers honour both. A product publishing
+      -- both fails the singular-role conformance check (validation.sql.j2, INV-SEMANTIC-011), but
+      -- while it exists this deterministically prefers the canonical spelling over MAX(...) string
+      -- ordering, so an already-corrected product still reads its legacy-only predecessor.
+    , COALESCE(
+          MAX(CASE WHEN o.resource_role = 'TRUST_MAP' THEN o.fully_qualified_object_name END)
+        , MAX(CASE WHEN o.resource_role = 'TRUST_GATE' THEN o.fully_qualified_object_name END)
+      )
     , MAX(CASE WHEN o.resource_role = 'MODULE_MAP'             THEN o.fully_qualified_object_name END)
     , MAX(CASE WHEN o.resource_role = 'OBJECT_CATALOGUE'       THEN o.fully_qualified_object_name END)
     , MAX(CASE WHEN o.resource_role = 'ENTITY_CATALOGUE'       THEN o.fully_qualified_object_name END)

--- a/implementation/teradata/modules/semantic/validation.sql.j2
+++ b/implementation/teradata/modules/semantic/validation.sql.j2
@@ -122,11 +122,19 @@ WHERE r.is_active = 1
              OR (req.resource_role = 'TRUST_MAP' AND o.resource_role = 'TRUST_GATE')))
 GROUP BY r.product_id, req.resource_role;
 
--- INV-SEMANTIC-011: duplicate active role for one product (each role is singular)
-SELECT product_id, resource_role, COUNT(*) AS n
-FROM {{ product }}_Semantic.data_product_orientation
-WHERE is_active = 1
-GROUP BY product_id, resource_role
+-- INV-SEMANTIC-011: duplicate active role for one product (each role is singular). TRUST_GATE and
+-- TRUST_MAP are the same role under two spellings (see the manifest's alias projection below), so
+-- they are canonicalised before grouping - otherwise a product publishing both passes this check.
+SELECT product_id, canonical_resource_role, COUNT(*) AS n
+FROM (
+    SELECT product_id
+         , CASE WHEN resource_role IN ('TRUST_MAP', 'TRUST_GATE') THEN 'TRUST_MAP'
+                ELSE resource_role
+           END AS canonical_resource_role
+    FROM {{ product }}_Semantic.data_product_orientation
+    WHERE is_active = 1
+) AS c
+GROUP BY product_id, canonical_resource_role
 HAVING COUNT(*) > 1;
 
 -- INV-SEMANTIC-011: duplicate discovery_order for one product

--- a/implementation/teradata/patterns/validation/04-trust-map-views.sql
+++ b/implementation/teradata/patterns/validation/04-trust-map-views.sql
@@ -1,9 +1,12 @@
 -- Validation: trust-map view (Teradata). Binding of the trust map and its consumption contract
--- in design/patterns/validation.md §4, §9, §10.
+-- in design/patterns/validation.md §4, §9, §10, §11.
 -- Latest-per-(product, producer, area) projection, with coverage derived on read. The deterministic
 -- tie-break (completed_dts DESC, run_id DESC) is part of the contract (VAL-09).
 -- A producer publishing no area rows is at wire schema 2.0; its run record projects a single
 -- PRODUCT-scope entry here, capped at 'partial' confidence, so the map has one shape everywhere.
+-- Staleness (§11) is evaluated per area against the run that actually produced it, not against
+-- the producer's latest run: two areas in this map can come from different runs, so evaluating
+-- staleness against "the latest run" would grade older evidence by a newer run's clock.
 -- {db} is a generic tag, e.g. {Product}_Observability.
 
 REPLACE VIEW {db}.validation_trust_map
@@ -26,33 +29,51 @@ SELECT
     , a.critical_failure_count
     , a.error_failure_count
     , a.area_status
-    , a.confidence
+    -- Stale evidence reads at 'unknown' whatever it recorded (§11); the run's own declared
+    -- expiry wins, else the default 7-day window from the completion this area belongs to.
+    , CASE WHEN a.evidence_is_stale = 1 THEN 'unknown' ELSE a.confidence END AS confidence
+    , a.confidence AS recorded_confidence
+    , a.evidence_is_stale
     , a.open_gaps
-    , a.recommended_action
+    , CASE WHEN a.evidence_is_stale = 1
+           THEN 'Evidence has expired; re-run the validator for this area.'
+           ELSE a.recommended_action
+      END AS recommended_action
+    , a.recommended_action AS recorded_recommended_action
     , a.completed_dts
     , 'PUBLISHED' AS map_source
 -- The latest run per area is resolved in a derived table: QUALIFY is scoped to its own query
--- block, and nesting it keeps the projection unambiguous across the UNION below.
+-- block, and nesting it keeps the projection unambiguous across the UNION below. Joined to its
+-- own parent run (not the producer's latest run) so staleness reflects the evidence's own age.
 FROM (
     SELECT
-          product_prefix, producer_id, run_id
-        , scope_kind, scope_id
-        , checks_expected, checks_ran
-        , passed_count, failed_count, error_count
-        , critical_failure_count, error_failure_count
-        , area_status, confidence
-        , open_gaps, recommended_action
-        , completed_dts
-    FROM {db}.validation_area
+          la.product_prefix, la.producer_id, la.run_id
+        , la.scope_kind, la.scope_id
+        , la.checks_expected, la.checks_ran
+        , la.passed_count, la.failed_count, la.error_count
+        , la.critical_failure_count, la.error_failure_count
+        , la.area_status, la.confidence
+        , la.open_gaps, la.recommended_action
+        , la.completed_dts
+        , CASE WHEN COALESCE(r.evidence_expires_dts, la.completed_dts + INTERVAL '7' DAY)
+                    < CURRENT_TIMESTAMP(6)
+               THEN 1 ELSE 0
+          END AS evidence_is_stale
+    FROM {db}.validation_area AS la
+    INNER JOIN {db}.validation_run AS r
+            ON  r.product_prefix = la.product_prefix
+            AND r.producer_id    = la.producer_id
+            AND r.run_id         = la.run_id
     QUALIFY ROW_NUMBER() OVER (
-        PARTITION BY product_prefix, producer_id, scope_kind, scope_id
-        ORDER BY completed_dts DESC, run_id DESC
+        PARTITION BY la.product_prefix, la.producer_id, la.scope_kind, la.scope_id
+        ORDER BY la.completed_dts DESC, la.run_id DESC
     ) = 1
 ) AS a
 
 UNION ALL
 
--- Wire schema 2.0 / 1.0 fallback: derive one PRODUCT entry from the run counts (§10).
+-- Wire schema 2.0 / 1.0 fallback: derive one PRODUCT entry from the run counts (§10), staleness
+-- evaluated against this same run since there is only one row to derive it from.
 SELECT
       v.product_prefix
     , v.producer_id
@@ -72,25 +93,47 @@ SELECT
            ELSE 'pass'
       END AS area_status
       -- Capped at 'partial': a run-level pass says nothing about which areas it covered.
+    , CASE WHEN COALESCE(v.evidence_expires_dts, v.completed_dts + INTERVAL '7' DAY)
+                < CURRENT_TIMESTAMP(6)                           THEN 'unknown'
+           WHEN v.total_checks = 0                               THEN 'unknown'
+           WHEN v.critical_failure_count + v.error_failure_count > 0
+             OR v.error_count > 0                                THEN 'weak'
+           ELSE 'partial'
+      END AS confidence
     , CASE WHEN v.total_checks = 0                              THEN 'unknown'
            WHEN v.critical_failure_count + v.error_failure_count > 0
              OR v.error_count > 0                               THEN 'weak'
            ELSE 'partial'
-      END AS confidence
+      END AS recorded_confidence
+    , CASE WHEN COALESCE(v.evidence_expires_dts, v.completed_dts + INTERVAL '7' DAY)
+                < CURRENT_TIMESTAMP(6) THEN 1 ELSE 0
+      END AS evidence_is_stale
     , 'Producer publishes no per-area map (wire schema 2.0), so trust is stated for the whole product only and cannot be resolved to the area a query touches.' AS open_gaps
-    , 'Upgrade the validator to publish validation_area entries at wire schema 2.1.' AS recommended_action
+    , CASE WHEN COALESCE(v.evidence_expires_dts, v.completed_dts + INTERVAL '7' DAY)
+                < CURRENT_TIMESTAMP(6)
+           THEN 'Evidence has expired; re-run the validator for this product.'
+           ELSE 'Upgrade the validator to publish validation_area entries at wire schema 2.1.'
+      END AS recommended_action
+    , 'Upgrade the validator to publish validation_area entries at wire schema 2.1.' AS recorded_recommended_action
     , v.completed_dts
     , 'DERIVED' AS map_source
 FROM {db}.validation_latest AS v
-WHERE NOT EXISTS (
+-- Scoped to explicit legacy versions (never a lexical '< 2.1', which breaks on a future major
+-- version) and to THIS run: a malformed 2.1 run that published no area rows must fail VAL-18,
+-- not be quietly re-dressed as a legacy product. An older producer's historical 2.1 area rows
+-- do not suppress the fallback for a current 2.0 run from the same producer, because the
+-- existence check is scoped to v.run_id, not to the producer as a whole.
+WHERE v.payload_schema_version IN ('1.0', '2.0')
+  AND NOT EXISTS (
     SELECT 1
     FROM {db}.validation_area AS a
     WHERE a.product_prefix = v.product_prefix
       AND a.producer_id    = v.producer_id
+      AND a.run_id         = v.run_id
 );
 
 COMMENT ON VIEW {db}.validation_trust_map IS
-'Trust map - latest entry per product, producer and area, with coverage derived on read. Read the areas a query touches, proceed, and disclose their confidence and gaps. Nothing here withholds use of the product.';
+'Trust map - latest entry per product, producer and area; coverage and staleness derived on read against the evidence''s own run. Read the areas a query touches, proceed, and disclose confidence and gaps. Nothing here withholds use.';
 
 -- The authoritative map is the set of rows whose producer_id matches the trust-authoritative
 -- producer designated in the product's orientation metadata; other producers' rows are evidence.

--- a/implementation/teradata/patterns/validation/README.md
+++ b/implementation/teradata/patterns/validation/README.md
@@ -20,9 +20,9 @@ Teradata binding of [`design/patterns/validation.md`](../../../../design/pattern
 | `01-validation-run.sql` | The `validation_run` append-only history table (profile `EVENT_APPEND_ONLY`) and its statistics: the run-level summary. |
 | `02-views.sql` | `validation_latest`: the latest-per-(product, producer) run projection. |
 | `03-validation-area.sql` | The `validation_area` append-only trust map: one row per run per area, with its vocabularies CHECK-constrained. |
-| `04-trust-map-views.sql` | `validation_trust_map`: the latest entry per (product, producer, area), coverage derived on read, plus the derived `PRODUCT` entry for a 2.0 producer. |
-| `consumer-queries.sql` | The map read before analytical use, the whole map, the most-cautious composite, evidence age, advisory summary, failure detail, per-area and run trends. |
-| `conformance-queries.sql` | `DBC`/data checks for the VAL conformance rules. `{sem}` tags the product's Semantic container where an `ENTITY` scope is resolved. |
+| `04-trust-map-views.sql` | `validation_trust_map`: the latest entry per (product, producer, area), coverage and staleness derived on read against each area's own run, plus the derived `PRODUCT` entry for a 2.0/1.0 producer. |
+| `consumer-queries.sql` | The map read before analytical use (reconciled against the caller's requested scopes, so a missing area reads as explicit `no-evidence` rather than disappearing), the whole map, the most-cautious composite, run-level evidence-age context, advisory summary, failure detail, per-area and run trends. |
+| `conformance-queries.sql` | `DBC`/data checks for the VAL conformance rules. `{sem}` tags the product's Semantic container where `PRODUCT`, `MODULE`, and `ENTITY` scopes are resolved; `PATTERN`/`CAPABILITY` have no deployed catalogue and are a producer build-time assertion instead. |
 
 Deploy in file order: the views project the tables above them.
 

--- a/implementation/teradata/patterns/validation/conformance-queries.sql
+++ b/implementation/teradata/patterns/validation/conformance-queries.sql
@@ -35,6 +35,16 @@ WHERE data_product_trust_score    NOT BETWEEN 0 AND 100
    OR performance_readiness_score NOT BETWEEN 0 AND 100
    OR operational_readiness_score NOT BETWEEN 0 AND 100;
 
+-- VAL-09: an area's completed_dts is inherited from its parent run, so latest-per-area ordering
+-- matches latest-per-run and the trust map's staleness join (04-trust-map-views.sql) is sound.
+SELECT a.run_id, a.producer_id, a.scope_kind, a.scope_id, a.completed_dts, r.completed_dts AS run_completed_dts
+FROM {db}.validation_area AS a
+INNER JOIN {db}.validation_run AS r
+        ON  r.product_prefix = a.product_prefix
+        AND r.producer_id    = a.producer_id
+        AND r.run_id         = a.run_id
+WHERE a.completed_dts <> r.completed_dts;
+
 -- VAL-12: producer identity present (canonical schema)
 SELECT run_id
 FROM {db}.validation_run
@@ -44,6 +54,8 @@ WHERE producer_id IS NULL
 
 -- VAL-14: area vocabularies. The CHECK constraints on validation_area enforce the three closed
 -- vocabularies at insert; this catches a scope_id that names nothing, which no constraint can.
+-- Resolvable here for PRODUCT, MODULE and ENTITY against deployed catalogue metadata; PATTERN
+-- and CAPABILITY have no such catalogue and are a producer build-time assertion instead (§14).
 SELECT a.run_id, a.scope_kind, a.scope_id
 FROM {db}.validation_area AS a
 WHERE TRIM(a.scope_id) = '';
@@ -68,6 +80,29 @@ WHERE a.scope_kind = 'ENTITY'
           AND UPPER(e.entity_name) = UPPER(SUBSTRING(a.scope_id FROM
                                             POSITION('.' IN a.scope_id) + 1))
       );
+
+-- VAL-14 (MODULE scope resolves): every module-scoped area names a module the product actually
+-- deployed. {sem} is the product's Semantic container, e.g. {Product}_Semantic.
+SELECT a.run_id, a.scope_kind, a.scope_id
+FROM {db}.validation_area AS a
+WHERE a.scope_kind = 'MODULE'
+  AND NOT EXISTS (
+        SELECT 1
+        FROM {sem}.data_product_map AS dm
+        WHERE dm.is_active = 1
+          AND UPPER(dm.module_name) = UPPER(a.scope_id)
+      );
+
+-- VAL-14 (PRODUCT scope resolves): a PRODUCT-scoped area names this product, not another one.
+SELECT a.run_id, a.scope_kind, a.scope_id
+FROM {db}.validation_area AS a
+WHERE a.scope_kind = 'PRODUCT'
+  AND a.scope_id <> a.product_prefix;
+
+-- VAL-14 (PATTERN, CAPABILITY): these vocabularies have no deployed catalogue a consumer can
+-- resolve against, so a typo'd scope_id (e.g. 'CAPABILITY:reposrting') is caught only by the
+-- producer's own build-time assertion against its validator profile - not runtime SQL, which
+-- cannot see the profile. See design/patterns/validation.md §14 (VAL-14) for the split.
 
 -- VAL-15: per-area counts reconcile, and coverage cannot exceed what the profile defines
 SELECT run_id, producer_id, scope_kind, scope_id, checks_ran, checks_expected
@@ -109,6 +144,20 @@ WHERE NOT EXISTS (
         WHERE r.product_prefix = a.product_prefix
           AND r.producer_id    = a.producer_id
           AND r.run_id         = a.run_id
+      );
+
+-- VAL-18 (every 2.1 run publishes at least one area entry - not only a run with failures.
+-- Without this, a malformed 2.1 producer that publishes zero area rows is silently re-dressed
+-- as a legacy product by the trust map's schema 2.0/1.0 fallback (04-trust-map-views.sql).)
+SELECT r.run_id, r.producer_id, r.payload_schema_version
+FROM {db}.validation_run AS r
+WHERE r.payload_schema_version = '2.1'
+  AND NOT EXISTS (
+        SELECT 1
+        FROM {db}.validation_area AS a
+        WHERE a.product_prefix = r.product_prefix
+          AND a.producer_id    = r.producer_id
+          AND a.run_id         = r.run_id
       );
 
 -- VAL-18 (a run that found failures publishes somewhere for them to land)

--- a/implementation/teradata/patterns/validation/consumer-queries.sql
+++ b/implementation/teradata/patterns/validation/consumer-queries.sql
@@ -7,34 +7,44 @@
 -- would raise it; the consumer proceeds and reports what it read (§9: read, select, proceed, disclose).
 
 -- 1. The areas this query plan touches, read BEFORE analytical use.
--- :scope_keys is the set of 'KIND:id' keys the plan reaches - the modules, entities, patterns and
--- capabilities behind the objects resolved through AccessObject ('MODULE:domain',
--- 'ENTITY:domain.Ticket'). Concatenated rather than a two-column IN list, which Teradata does not
--- take as a literal row constructor. Take the narrowest entry that covers each.
+-- requested_validation_scope is a request-scoped relation (e.g. a volatile table) the caller
+-- populates with one (scope_kind, scope_id) row per module, entity, pattern or capability the
+-- plan reaches - the areas behind the objects resolved through AccessObject
+-- (('MODULE', 'domain'), ('ENTITY', 'domain.Ticket')). Kept as two columns rather than a
+-- concatenated 'KIND:id' key so the join uses real column statistics, not a computed string.
+-- Driving FROM the caller's own request (LEFT OUTER JOIN to the map, not the map filtered by the
+-- request) is what guarantees every requested area gets a row: a plain filter silently drops a
+-- scope the map has no entry for, which is the exact failure mode the trust map exists to remove.
 -- Rules: a row missing for an area means no-evidence / unknown, not sound;
--- a row whose evidence is stale reads at confidence 'unknown' whatever it recorded (query 4);
+-- a row whose evidence is stale reads at confidence 'unknown' whatever it recorded;
 -- never recount the run's capped JSON blobs.
-SELECT m.scope_kind
-     , m.scope_id
-     , m.area_status
-     , m.confidence
+SELECT s.scope_kind
+     , s.scope_id
+     , COALESCE(m.area_status, 'no-evidence') AS area_status
+     , COALESCE(m.confidence, 'unknown') AS confidence
+     , m.recorded_confidence
+     , COALESCE(m.evidence_is_stale, 0) AS evidence_is_stale
      , m.checks_ran
      , m.checks_expected
      , m.coverage_ratio
      , m.critical_failure_count
      , m.error_failure_count
-     , m.open_gaps
-     , m.recommended_action
-     , m.map_source
+     , COALESCE(m.open_gaps,
+           'No trust-map entry was published for an area used by this query.') AS open_gaps
+     , COALESCE(m.recommended_action,
+           'Add this area to the validator profile and publish a validation_area entry.') AS recommended_action
+     , COALESCE(m.map_source, 'NONE') AS map_source
      , m.completed_dts
-FROM {db}.validation_trust_map AS m
-WHERE m.product_prefix = :product_prefix
-  AND m.producer_id    = :trust_producer
-  AND m.scope_kind || ':' || m.scope_id IN (:scope_keys)
-ORDER BY CASE m.confidence WHEN 'unknown' THEN 1 WHEN 'weak' THEN 2
-                           WHEN 'partial' THEN 3 ELSE 4 END
-       , m.scope_kind
-       , m.scope_id;
+FROM requested_validation_scope AS s
+LEFT OUTER JOIN {db}.validation_trust_map AS m
+             ON  m.product_prefix = :product_prefix
+             AND m.producer_id    = :trust_producer
+             AND m.scope_kind     = s.scope_kind
+             AND m.scope_id       = s.scope_id
+ORDER BY CASE COALESCE(m.confidence, 'unknown')
+              WHEN 'unknown' THEN 1 WHEN 'weak' THEN 2 WHEN 'partial' THEN 3 ELSE 4 END
+       , s.scope_kind
+       , s.scope_id;
 
 -- 2. The whole map, for orientation and for reporting where a product is strong and where it is not.
 SELECT m.scope_kind
@@ -61,18 +71,16 @@ WHERE m.product_prefix = :product_prefix
 GROUP BY m.scope_kind, m.scope_id
 ORDER BY lowest_confidence_rank, m.scope_kind, m.scope_id;
 
--- 4. Evidence age for the authoritative map: staleness downgrades confidence to 'unknown'
--- and is disclosed with its date. It never blocks. The window is the producer's declared
--- expiry, else the product's declared maximum age, else 7 days from completed_dts.
+-- 4. Evidence age for the producer's most recent run, for run-history context only. Staleness
+-- that governs what a consumer may say about an AREA is already folded into query 1/2's
+-- confidence and evidence_is_stale columns, evaluated against each area's own run (§11) - do not
+-- recompute it from this producer-latest row, which can be newer than the area actually read.
 SELECT v.producer_id
      , v.completed_dts
      , v.evidence_expires_dts
      , v.payload_schema_version
-     , CASE WHEN v.evidence_expires_dts IS NOT NULL
-              AND v.evidence_expires_dts < CURRENT_TIMESTAMP(6)                     THEN 1
-            WHEN v.evidence_expires_dts IS NULL
-              AND v.completed_dts < CURRENT_TIMESTAMP(6) - INTERVAL '7' DAY          THEN 1
-            ELSE 0
+     , CASE WHEN COALESCE(v.evidence_expires_dts, v.completed_dts + INTERVAL '7' DAY)
+                < CURRENT_TIMESTAMP(6) THEN 1 ELSE 0
        END AS evidence_is_stale
 FROM {db}.validation_latest AS v
 WHERE v.product_prefix = :product_prefix


### PR DESCRIPTION
Addresses the five requested changes from @earthshiner's review on #57, targeted at that PR's branch so it merges into the per-area trust map work rather than main directly.

## Changes

1. **Staleness evaluated per-area against its own run** — `validation_trust_map` now joins each area to its parent `validation_run` (not the producer's latest run) and downgrades `confidence` to `unknown` when that area's own evidence has expired. `recorded_confidence` / `recorded_recommended_action` preserve the original verdict. Added VAL-09 conformance check that `validation_area.completed_dts` matches its parent run's.
2. **Legacy fallback scoped correctly** — the derived 2.0/1.0 `PRODUCT` entry now requires `payload_schema_version IN ('1.0','2.0')` and checks for area rows on the current run only, not "ever, for this producer." Added a VAL-18 check flagging any 2.1 run that publishes zero area rows.
3. **Missing areas surface explicitly** — the pre-use query now drives from the caller's requested scopes with a `LEFT OUTER JOIN` to the map, so a requested area with no map entry returns explicit `no-evidence` / `unknown` with an actionable message instead of disappearing from the result.
4. **VAL-14 resolves more scope kinds** — added checks that `MODULE` resolves against `data_product_map` and `PRODUCT` resolves to the product's own prefix. `PATTERN` / `CAPABILITY` have no deployed catalogue to check at runtime, so that split is now documented explicitly rather than implied.
5. **TRUST_GATE / TRUST_MAP treated as one role** — the duplicate-role conformance check canonicalises both spellings before grouping; the manifest's entrypoint projection uses a deterministic `COALESCE` instead of `MAX(...)` string ordering.

## Test plan

- [x] `python tooling/validation/design_lint.py design implementation` — clean
- [x] `python tooling/skill/verify_skill.py` — package conforms
- [x] `python -m pytest tooling` — 97 passed, 3 skipped
- [ ] Fixture-based tests for the new staleness/fallback/scope-resolution scenarios (review recommended a `test_validation_trust_map.py` — not yet added, happy to follow up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)